### PR TITLE
[AF-17] Staff Authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 ## [Unreleased]
 
-## [0.4.0] - 2024-02-24
+## [0.4.1] - 2024-02-20
+
+### Added
+
+- Authentication for staff members.
+- Only active staff member can authenticate.
+
+## [0.4.0] - 2024-02-20
 
 ### Added
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    auction_fun_core (0.4.0)
+    auction_fun_core (0.4.1)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/auction_fun_core/contracts/staff_context/authentication_contract.rb
+++ b/lib/auction_fun_core/contracts/staff_context/authentication_contract.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module AuctionFunCore
+  module Contracts
+    module StaffContext
+      # Contract class to authenticate staff.
+      class AuthenticationContract < ApplicationContract
+        I18N_SCOPE = "contracts.errors.custom.default"
+
+        option :staff_repository, default: proc { Repos::StaffContext::StaffRepository.new }
+
+        params do
+          required(:login)
+          required(:password)
+
+          before(:value_coercer) do |result|
+            result.to_h.compact
+          end
+        end
+
+        rule(:login).validate(:login_format)
+        rule(:password).validate(:password_format)
+
+        # Validation for login.
+        # Searches for the staff in the database from the login, and, if found,
+        # compares the entered password.
+        rule do |context:|
+          next if (rule_error?(:login) || schema_error?(:login)) || (rule_error?(:password) || schema_error?(:password))
+
+          context[:staff] ||= staff_repository.by_login(values[:login])
+
+          next if context[:staff].present? && context[:staff].active? && (BCrypt::Password.new(context[:staff].password_digest) == values[:password])
+
+          if context[:staff].blank? || (BCrypt::Password.new(context[:staff].password_digest) != values[:password])
+            key(:base).failure(I18n.t("login_not_found", scope: I18N_SCOPE))
+          end
+
+          if context[:staff].present? && context[:staff].inactive?
+            key(:base).failure(I18n.t("inactive_account", scope: I18N_SCOPE))
+          end
+
+          key(:base).failure(I18n.t("login_not_found", scope: I18N_SCOPE))
+        end
+      end
+    end
+  end
+end

--- a/lib/auction_fun_core/entities/staff.rb
+++ b/lib/auction_fun_core/entities/staff.rb
@@ -5,6 +5,14 @@ module AuctionFunCore
     # Staff Relations class. This return simple objects with attribute readers
     # to represent data in your staff.
     class Staff < ROM::Struct
+      def active?
+        active
+      end
+
+      def inactive?
+        !active
+      end
+
       def info
         attributes.except(:password_digest)
       end

--- a/lib/auction_fun_core/events/app.rb
+++ b/lib/auction_fun_core/events/app.rb
@@ -8,6 +8,7 @@ module AuctionFunCore
       # @!parser include Dry::Events::Publisher[:app]
       include Dry::Events::Publisher[:app]
 
+      register_event("staffs.authentication")
       register_event("staffs.registration")
 
       register_event("users.authentication")

--- a/lib/auction_fun_core/events/listener.rb
+++ b/lib/auction_fun_core/events/listener.rb
@@ -5,6 +5,14 @@ module AuctionFunCore
     # Event class that can listen business events.
     # @see https://dry-rb.org/gems/dry-events/main/#event-listeners
     class Listener
+      # Listener for to *staffs.authentication* event.
+      # @param attributes [Hash] Authentication attributes
+      # @option staff_id [Integer] Staff ID
+      # @option time [DateTime] Authentication time
+      def on_staffs_authentication(attributes)
+        logger("Staff #{attributes[:staff_id]} authenticated on: #{attributes[:time].iso8601}")
+      end
+
       # Listener for to *staffs.registration* event.
       # @param user [ROM::Struct::Staff] the staff object
       def on_staffs_registration(staff)

--- a/lib/auction_fun_core/operations/staff_context/authentication_operation.rb
+++ b/lib/auction_fun_core/operations/staff_context/authentication_operation.rb
@@ -2,12 +2,12 @@
 
 module AuctionFunCore
   module Operations
-    module UserContext
+    module StaffContext
       ##
-      # Operation class for authenticate users.
+      # Operation class for authenticate staff members.
       #
       class AuthenticationOperation < AuctionFunCore::Operations::Base
-        include Import["contracts.user_context.authentication_contract"]
+        include Import["contracts.staff_context.authentication_contract"]
 
         def self.call(attributes, &block)
           operation = new.call(attributes)
@@ -19,31 +19,31 @@ module AuctionFunCore
 
         # @todo Add custom doc
         def call(attributes)
-          user = yield validate_contract(attributes)
+          staff = yield validate_contract(attributes)
 
-          yield publish_user_authentication(user.id)
+          yield publish_staff_authentication(staff.id)
 
-          Success(user)
+          Success(staff)
         end
 
         # Calls the authentication contract class to perform the validation
         # and authentication of the informed attributes.
-        # @param attrs [Hash] user attributes
+        # @param attrs [Hash] Staff attributes
         # @return [Dry::Monads::Result::Success, Dry::Monads::Result::Failure]
         def validate_contract(attrs)
           contract = authentication_contract.call(attrs)
 
           return Failure(contract.errors.to_h) if contract.failure?
 
-          Success(contract.context[:user])
+          Success(contract.context[:staff])
         end
 
-        # Triggers the publication of event *users.registration*.
-        # @param user_id [Integer] User ID
+        # Triggers the publication of event *staffs.registration*.
+        # @param staff_id [Integer] Staff ID
         # @return [Dry::Monads::Result::Success]
-        def publish_user_authentication(user_id, time = Time.current)
+        def publish_staff_authentication(staff_id, time = Time.current)
           Success(
-            Application[:event].publish("users.authentication", {user_id: user_id, time: time})
+            Application[:event].publish("staffs.authentication", {staff_id: staff_id, time: time})
           )
         end
       end

--- a/lib/auction_fun_core/repos/staff_context/staff_repository.rb
+++ b/lib/auction_fun_core/repos/staff_context/staff_repository.rb
@@ -44,6 +44,13 @@ module AuctionFunCore
           staffs.by_pk(id).one!
         end
 
+        # Search staff in database by email of phone keys.
+        # @param login [String] Staff email or phone
+        # @return [ROM::Struct::Staff, nil]
+        def by_login(login)
+          staffs.where(Sequel[email: login] | Sequel[phone: login]).one
+        end
+
         # Checks if it returns any staff given one or more conditions.
         # @param conditions [Hash] DSL Dataset
         # @return [true] when some staff is returned from the given condition.

--- a/lib/auction_fun_core/version.rb
+++ b/lib/auction_fun_core/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module AuctionFunCore
-  VERSION = "0.4.0"
+  VERSION = "0.4.1"
 
   # Required class module is a gem dependency
   class Version; end

--- a/spec/auction_fun_core/contracts/staff_context/authentication_contract_spec.rb
+++ b/spec/auction_fun_core/contracts/staff_context/authentication_contract_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe AuctionFunCore::Contracts::StaffContext::AuthenticationContract, type: :contract do
+  describe "#call" do
+    subject(:contract) { described_class.new.call(attributes) }
+
+    context "when params are blank" do
+      let(:attributes) { {} }
+
+      it "expect failure with error messages" do
+        expect(contract).to be_failure
+        expect(contract.errors[:login]).to include(I18n.t("contracts.errors.key?"))
+        expect(contract.errors[:password]).to include(I18n.t("contracts.errors.key?"))
+      end
+    end
+
+    context "when login params are invalid" do
+      context "when email is invalid" do
+        let(:attributes) { {login: "invalid_email"} }
+
+        it "expect failure with error messages" do
+          expect(contract).to be_failure
+          expect(contract.errors[:login]).to include(
+            I18n.t("contracts.errors.custom.macro.login_format")
+          )
+        end
+      end
+
+      context "when phone is invalid" do
+        let(:attributes) { {login: "12345"} }
+
+        it "expect failure with error messages" do
+          expect(contract).to be_failure
+          expect(contract.errors[:login]).to include(
+            I18n.t("contracts.errors.custom.macro.login_format")
+          )
+        end
+      end
+    end
+
+    context "with database" do
+      context "when login is not found on database" do
+        let(:attributes) { {login: "notfound@staff.com", password: "example"} }
+
+        it "expect failure with error messages" do
+          expect(contract).to be_failure
+          expect(contract.errors[:base]).to include(
+            I18n.t("contracts.errors.custom.default.login_not_found")
+          )
+        end
+      end
+
+      context "when password doesn't match with storage password on database" do
+        let(:staff) { Factory[:staff] }
+        let(:attributes) { {login: staff.email, password: "invalid"} }
+
+        it "expect failure with error messages" do
+          expect(contract).to be_failure
+          expect(contract.errors[:base]).to include(
+            I18n.t("contracts.errors.custom.default.login_not_found")
+          )
+        end
+      end
+
+      context "when credentials are valid but user is inactive" do
+        let(:staff) { Factory[:staff, :inactive] }
+        let(:attributes) { {login: staff.email, password: "password"} }
+
+        it "expect failure with error messages" do
+          expect(contract).to be_failure
+          expect(contract.errors[:base]).to include(
+            I18n.t("contracts.errors.custom.default.inactive_account")
+          )
+        end
+      end
+    end
+
+    context "when credentials are valid" do
+      let(:staff) { Factory[:staff] }
+      let(:attributes) { {login: staff.email, password: "password"} }
+
+      it "expect return success" do
+        expect(contract).to be_success
+      end
+    end
+  end
+end

--- a/spec/auction_fun_core/operations/staff_context/authentication_operation_spec.rb
+++ b/spec/auction_fun_core/operations/staff_context/authentication_operation_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe AuctionFunCore::Operations::StaffContext::AuthenticationOperation, type: :operation do
+  let(:staff_repo) { AuctionCore::Repos::StaffRepo.new }
+
+  describe ".call(attributes, &block)" do
+    let(:operation) { described_class }
+
+    context "when block is given" do
+      context "when operation happens with success" do
+        let(:staff) { Factory[:staff] }
+        let(:attributes) { {login: staff.email, password: "password"} }
+
+        it "expect result success matching block" do
+          matched_success = nil
+          matched_failure = nil
+
+          operation.call(attributes) do |o|
+            o.success { |v| matched_success = v }
+            o.failure { |f| matched_failure = f }
+          end
+
+          expect(matched_success).to be_a(AuctionFunCore::Entities::Staff)
+          expect(matched_failure).to be_nil
+        end
+      end
+
+      context "when operation happens with failure" do
+        let(:attributes) { Dry::Core::Constants::EMPTY_HASH }
+
+        it "expect result matching block" do
+          matched_success = nil
+          matched_failure = nil
+
+          operation.call(attributes) do |o|
+            o.success { |v| matched_success = v }
+            o.failure { |f| matched_failure = f }
+          end
+
+          expect(matched_success).to be_nil
+          expect(matched_failure[:login]).to include(I18n.t("contracts.errors.key?"))
+        end
+      end
+    end
+  end
+
+  describe "#call(attributes)" do
+    subject(:operation) { described_class.new.call(attributes) }
+
+    context "when contract are invalid" do
+      let(:attributes) { Dry::Core::Constants::EMPTY_HASH }
+
+      it "expect return failure with error messages" do
+        expect(operation).to be_failure
+        expect(operation.failure[:login]).to include(I18n.t("contracts.errors.key?"))
+      end
+    end
+
+    context "when contract are valid" do
+      let(:staff) { Factory[:staff] }
+      let(:attributes) { {login: staff.email, password: "password"} }
+
+      before do
+        allow(AuctionFunCore::Application[:event]).to receive(:publish)
+      end
+
+      it "expect return success" do
+        expect(operation).to be_success
+
+        expect(AuctionFunCore::Application[:event]).to have_received(:publish).once
+      end
+    end
+  end
+end

--- a/spec/auction_fun_core_spec.rb
+++ b/spec/auction_fun_core_spec.rb
@@ -2,6 +2,6 @@
 
 RSpec.describe AuctionFunCore do
   it "has a version number" do
-    expect(AuctionFunCore::VERSION).to eq("0.4.0")
+    expect(AuctionFunCore::VERSION).to eq("0.4.1")
   end
 end


### PR DESCRIPTION
Issue number: resolves #17 

## Summary :red_circle:

This PR adds the staff authentication feature. Additional add-ons are available in the changelog in version `0.4.1`.

## Proposed / Possible solution :red_circle:

We only added the contract and the operation, as it is an action within the staff context.

## How to test :policeman:

Start the related services, and open the console with the command bin/console. After that:

```ruby
attributes = {}

AuctionFunCore::Operations::StaffContext::AuthenticationOperation.call(attributes) do |result|
  result.success { |staff| puts staff.to_h }
  result.failure { |failure| puts failure.to_h }
end
```

> To simulate successful authentication, change the hash of the attributes variable so that it meets all contract requirements.

## Risks / Impacts :red_circle:

- None anticipated

## Requirements for deployment :red_circle:

- None anticipated