### PR TITLE
[AF-3] Create currencies

### DIFF
--- a/.env.development.template
+++ b/.env.development.template
@@ -1,6 +1,7 @@
 APP_ENV=development
 DATABASE_URL=postgresql://postgres:@127.0.0.1/auction_fun_core_development?pool=10
 REDIS_URL=redis://localhost:6379/0
+DEFAULT_CURRENCY=USD
 DEFAULT_EMAIL_SYSTEM=system@auctionfun.app
 SMTP_ADDRESS=localhost
 SMTP_PORT=1025

--- a/.env.test.template
+++ b/.env.test.template
@@ -1,6 +1,7 @@
 APP_ENV=test
 DATABASE_URL=postgresql://postgres:@127.0.0.1:5432/auction_fun_core_test?pool=10
 REDIS_URL=redis://localhost:6379/15
+DEFAULT_CURRENCY=USD
 DEFAULT_EMAIL_SYSTEM=system@auctionfun.app
 SMTP_ADDRESS=localhost
 SMTP_PORT=1025

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## [Unreleased]
 
+## [0.6.1] - 2024-02-28
+
+### Added
+
+- Add configuration to handle monetary values.
+- Add required environment variable `DEFAULT_CURRENCY` to set the default currency.
+- Tests for entities.
+
 ## [0.6.0] - 2024-02-24
 
 ### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    auction_fun_core (0.6.0)
+    auction_fun_core (0.6.1)
 
 GEM
   remote: https://rubygems.org/

--- a/config/application.rb
+++ b/config/application.rb
@@ -9,10 +9,12 @@ require "dry/system"
 require "dry/system/loader/autoloading"
 require "dry/auto_inject"
 require "dry/types"
+require "money"
 
 module AuctionFunCore
   # Main class (Add doc)
   class Application < Dry::System::Container
+    Money.default_currency = ENV.fetch("DEFAULT_CURRENCY")
     I18n.load_path += Dir[File.expand_path("i18n/**/*.{rb,yml}")]
     I18n.available_locales = %w[en-US pt-BR]
     I18n.default_locale = "pt-BR"

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -9,6 +9,7 @@ unless defined?(Dotenv)
   require "dotenv"
   Dotenv.load(".env.#{ENV.fetch("APP_ENV", nil)}")
   Dotenv.require_keys(
-    "DATABASE_URL", "REDIS_URL", "DEFAULT_EMAIL_SYSTEM", "SMTP_ADDRESS", "SMTP_PORT"
+    "DATABASE_URL", "DEFAULT_CURRENCY", "DEFAULT_EMAIL_SYSTEM", "REDIS_URL",
+    "SMTP_ADDRESS", "SMTP_PORT"
   )
 end

--- a/db/migrate/20240217115734_create_users.rb
+++ b/db/migrate/20240217115734_create_users.rb
@@ -9,6 +9,8 @@ ROM::SQL.migration do
       column :phone, String, null: false
       column :password_digest, String, null: false
       column :active, TrueClass, null: false, default: true
+      column :balance_cents, Integer, null: false, default: 0
+      column :balance_currency, String, null: false, default: "USD"
       column :email_confirmation_token, String, size: 20
       column :phone_confirmation_token, String, size: 6
       column :email_confirmation_at, DateTime

--- a/lib/auction_fun_core/entities/user.rb
+++ b/lib/auction_fun_core/entities/user.rb
@@ -28,6 +28,10 @@ module AuctionFunCore
       def info
         attributes.except(:password_digest)
       end
+
+      def balance
+        Money.new(balance_cents, balance_currency)
+      end
     end
   end
 end

--- a/lib/auction_fun_core/relations/users.rb
+++ b/lib/auction_fun_core/relations/users.rb
@@ -13,6 +13,8 @@ module AuctionFunCore
         attribute :email, Types::String
         attribute :phone, Types::String
         attribute :active, Types::Bool
+        attribute :balance_cents, Types::Integer
+        attribute :balance_currency, Types::String
 
         primary_key :id
       end

--- a/lib/auction_fun_core/version.rb
+++ b/lib/auction_fun_core/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module AuctionFunCore
-  VERSION = "0.6.0"
+  VERSION = "0.6.1"
 
   # Required class module is a gem dependency
   class Version; end

--- a/spec/auction_fun_core/entities/staff_spec.rb
+++ b/spec/auction_fun_core/entities/staff_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe AuctionFunCore::Entities::Staff, type: :entity do
+  describe "#active?" do
+    subject(:staff) { Factory.structs[:staff] }
+
+    it "expect return true when staff is active" do
+      expect(staff).to be_active
+    end
+  end
+
+  describe "#inactive?" do
+    subject(:staff) { Factory.structs[:staff, :inactive] }
+
+    it "expect return false when staff is not active" do
+      expect(staff).to be_inactive
+    end
+  end
+
+  describe "#info" do
+    subject(:staff) { Factory.structs[:staff] }
+
+    it "expect return hash with some staff fields" do
+      expect(staff.info).to eq({
+        active: staff.active,
+        created_at: staff.created_at,
+        email: staff.email,
+        id: staff.id,
+        kind: staff.kind,
+        name: staff.name,
+        phone: staff.phone,
+        updated_at: staff.updated_at
+      })
+    end
+  end
+end

--- a/spec/auction_fun_core/entities/user_spec.rb
+++ b/spec/auction_fun_core/entities/user_spec.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe AuctionFunCore::Entities::User, type: :entity do
+  describe "#active?" do
+    subject(:user) { Factory.structs[:user] }
+
+    it "expect return true when user is active" do
+      expect(user).to be_active
+    end
+  end
+
+  describe "#inactive?" do
+    subject(:user) { Factory.structs[:user, :inactive] }
+
+    it "expect return false when user is not active" do
+      expect(user).to be_inactive
+    end
+  end
+
+  describe "#confirmed?" do
+    context "when confirmed_at is present" do
+      subject(:user) { Factory.structs[:user] }
+
+      it "expect return true" do
+        expect(user).to be_confirmed
+      end
+    end
+
+    context "when confirmed_at is blank" do
+      subject(:user) { Factory.structs[:user, confirmed_at: nil] }
+
+      it "expect return false" do
+        expect(user).not_to be_confirmed
+      end
+    end
+  end
+
+  describe "#email_confirmed?" do
+    context "when email_confirmation_at is present" do
+      subject(:user) { Factory.structs[:user] }
+
+      it "expect return true" do
+        expect(user).to be_email_confirmed
+      end
+    end
+
+    context "when email_confirmation_at is blank" do
+      subject(:user) { Factory.structs[:user, email_confirmation_at: nil] }
+
+      it "expect return false" do
+        expect(user).not_to be_email_confirmed
+      end
+    end
+  end
+
+  describe "#phone_confirmed?" do
+    context "when phone_confirmation_at is present" do
+      subject(:user) { Factory.structs[:user] }
+
+      it "expect return true" do
+        expect(user).to be_phone_confirmed
+      end
+    end
+
+    context "when phone_confirmation_at is blank" do
+      subject(:user) { Factory.structs[:user, phone_confirmation_at: nil] }
+
+      it "expect return false" do
+        expect(user).not_to be_phone_confirmed
+      end
+    end
+  end
+
+  describe "#info" do
+    subject(:user) { Factory.structs[:user, :with_balance] }
+
+    it "expect return hash with some user fields" do
+      expect(user.info).to eq({
+        active: user.active,
+        balance_cents: user.balance_cents,
+        balance_currency: user.balance_currency,
+        confirmed_at: user.confirmed_at,
+        created_at: user.created_at,
+        email: user.email,
+        email_confirmation_at: user.email_confirmation_at,
+        email_confirmation_token: user.email_confirmation_token,
+        id: user.id,
+        name: user.name,
+        phone: user.phone,
+        phone_confirmation_at: user.phone_confirmation_at,
+        phone_confirmation_token: user.phone_confirmation_token,
+        updated_at: user.updated_at
+      })
+    end
+  end
+
+  describe "#balance" do
+    subject(:user) { Factory.structs[:user, :with_balance] }
+
+    it "expect return false when user is not active" do
+      expect(user.balance).to be_a_instance_of(Money)
+    end
+  end
+end

--- a/spec/auction_fun_core_spec.rb
+++ b/spec/auction_fun_core_spec.rb
@@ -2,6 +2,6 @@
 
 RSpec.describe AuctionFunCore do
   it "has a version number" do
-    expect(AuctionFunCore::VERSION).to eq("0.6.0")
+    expect(AuctionFunCore::VERSION).to eq("0.6.1")
   end
 end

--- a/spec/support/factories/staffs.rb
+++ b/spec/support/factories/staffs.rb
@@ -5,6 +5,8 @@ Factory.define(:staff, struct_namespace: AuctionFunCore::Entities) do |f|
   f.email { fake(:internet, :email) }
   f.phone { fake(:phone_number, :cell_phone_in_e164).tr_s("^0-9", "") }
   f.password_digest { BCrypt::Password.create("password") }
+  f.kind { "common" }
+  f.active { true }
 
   f.trait :with_root_kind do |t|
     t.kind { "root" }

--- a/spec/support/factories/users.rb
+++ b/spec/support/factories/users.rb
@@ -8,6 +8,7 @@ Factory.define(:user, struct_namespace: AuctionFunCore::Entities) do |f|
   f.email_confirmation_at { Time.current - 1.day }
   f.phone_confirmation_at { Time.current - 1.day }
   f.confirmed_at { Time.current }
+  f.active { true }
 
   f.trait :inactive do |t|
     t.active { false }
@@ -33,5 +34,10 @@ Factory.define(:user, struct_namespace: AuctionFunCore::Entities) do |f|
 
   f.trait :with_phone_confirmation_token do |t|
     t.phone_confirmation_token { AuctionFunCore::Business::TokenGenerator.generate_phone_token }
+  end
+
+  f.trait :with_balance do |t|
+    t.balance_cents { 1000 }
+    t.balance_currency { Money.default_currency }
   end
 end

--- a/spec/support/factories/users.rb
+++ b/spec/support/factories/users.rb
@@ -38,6 +38,6 @@ Factory.define(:user, struct_namespace: AuctionFunCore::Entities) do |f|
 
   f.trait :with_balance do |t|
     t.balance_cents { 1000 }
-    t.balance_currency { Money.default_currency }
+    t.balance_currency { AuctionFunCore::Application[:settings].default_currency }
   end
 end

--- a/spec/support/faker.rb
+++ b/spec/support/faker.rb
@@ -2,5 +2,5 @@
 
 if defined?(Faker)
   I18n.enforce_available_locales = false
-  Faker::Config.locale = 'pt-BR'
+  Faker::Config.locale = "pt-BR"
 end

--- a/system/providers/settings.rb
+++ b/system/providers/settings.rb
@@ -5,10 +5,6 @@ require "dry/system/provider_sources"
 # This file uses the rom gem to define a database configuration container
 # and registers it with our application under the container key.
 AuctionFunCore::Application.register_provider(:settings, from: :dry_system) do
-  before :prepare do
-    require "money"
-  end
-
   settings do
     setting :logger, default: Logger.new($stdout)
     setting :database_url, default: ENV.fetch("DATABASE_URL"),
@@ -25,6 +21,6 @@ AuctionFunCore::Application.register_provider(:settings, from: :dry_system) do
     setting :smtp_port, default: ENV.fetch("SMTP_PORT"),
       constructor: Dry::Types["string"].constrained(filled: true)
     setting :default_currency, constructor: Dry::Types["string"].constrained(filled: true),
-      default: Money::Currency.new(ENV.fetch("DEFAULT_CURRENCY"))
+      default: Money.default_currency
   end
 end

--- a/system/providers/settings.rb
+++ b/system/providers/settings.rb
@@ -24,5 +24,7 @@ AuctionFunCore::Application.register_provider(:settings, from: :dry_system) do
       constructor: Dry::Types["string"].constrained(filled: true)
     setting :smtp_port, default: ENV.fetch("SMTP_PORT"),
       constructor: Dry::Types["string"].constrained(filled: true)
+    setting :default_currency, constructor: Dry::Types["string"].constrained(filled: true),
+      default: Money::Currency.new(ENV.fetch("DEFAULT_CURRENCY"))
   end
 end


### PR DESCRIPTION
Issue number: resolves #3 

## Summary :red_circle:

This PR adds the necessary features for handle currencies. Additional add-ons are available in the changelog in version `0.6.1`.

## Proposed / Possible solution :red_circle:

We made use of the money gem dependency to deal with financial values. They have a simple and standardized way of dealing with currencies and also conversions between them. We will use ISO 4217 to guide us regarding currencies and rules.

We did a refactoring unrelated to the main feature, which is adding automated tests for entities.

## How to test :policeman:

Start the related services, and open the console with the command bin/console. Here you can call the user repository, which will instantiate a user's balance using the money gem, and use the methods and possibilities available in the money gem's official documentation.

## Risks / Impacts :red_circle:

- None anticipated

## Requirements for deployment :red_circle:

- None anticipated