### PR TITLE
[AF-4] Create auctions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 ## [Unreleased]
 
+## [0.7.0] - 2024-02-29
+
+### Added
+
+- Auction entity and your context to handle auction creation business rules.
+- Internal Processor module in auctions to handle specific actions.
+- User-defined Data Types (custom types) for postgres.
+
+### Fixed
+
+- `en-US` i18n contract messages.
+
 ## [0.6.1] - 2024-02-28
 
 ### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    auction_fun_core (0.6.1)
+    auction_fun_core (0.7.0)
 
 GEM
   remote: https://rubygems.org/

--- a/db/migrate/20240229142933_create_custom_types.rb
+++ b/db/migrate/20240229142933_create_custom_types.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+ROM::SQL.migration do
+  up do
+    run "CREATE TYPE auction_kinds AS ENUM('standard', 'penny', 'closed')"
+    run "CREATE TYPE auction_statuses AS ENUM('scheduled', 'running', 'paused', 'canceled', 'finished')"
+  end
+
+  down do
+    run 'DROP TYPE IF EXISTS "auction_kinds"'
+    run 'DROP TYPE IF EXISTS "auction_statuses"'
+  end
+end

--- a/db/migrate/20240229143000_enable_auctions.rb
+++ b/db/migrate/20240229143000_enable_auctions.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+ROM::SQL.migration do
+  change do
+    create_table(:auctions) do
+      primary_key :id
+      foreign_key :staff_id, :staffs, null: false
+      column :title, String, null: false
+      column :description, :text
+      column :kind, :auction_kinds, null: false
+      column :status, :auction_statuses, null: false
+      column :started_at, DateTime, null: false
+      column :finished_at, DateTime
+      column :stopwatch, Integer, null: false, default: 0
+      column :initial_bid_cents, Integer, null: false, default: 0
+      column :initial_bid_currency, String, null: false, default: "USD"
+      column :minimal_bid_cents, Integer, null: false, default: 0
+      column :minimal_bid_currency, String, null: false, default: "USD"
+      column :metadata, :jsonb, null: false, default: "{}"
+      column :statistics, :jsonb, null: false, default: "{}"
+
+      column :created_at, DateTime, null: false
+      column :updated_at, DateTime, null: false
+    end
+
+    add_index :auctions, %i[staff_id], name: "idx_admin"
+    add_index :auctions, %i[kind status], name: "idx_kind_status"
+  end
+end

--- a/i18n/en-US/contracts/contracts.en-US.yml
+++ b/i18n/en-US/contracts/contracts.en-US.yml
@@ -54,16 +54,19 @@ en-US:
               default: "length must be %{size}"
               range: "length must be within %{size_left} - %{size_right}"
       custom:
-        errors:
-          default:
-            taken: "has already been taken"
-            not_found: "not found"
-            password_confirmation: "doesn't match password"
-            login_not_found: "Invalid credentials"
-            inactive_account: "Your account is suspended or inactive"
-          macro:
-            email_format: "need to be a valid email"
-            login_format: "invalid login"
-            name_format: "must be between %{min} and %{max} characters"
-            password_format: "must be between %{min} and %{max} characters"
-            phone_format: "need to be a valid mobile number"
+        default:
+          taken: "has already been taken"
+          not_found: "not found"
+          password_confirmation: "doesn't match password"
+          login_not_found: "Invalid credentials"
+          inactive_account: "Your account is suspended or inactive"
+          future: "must be in the future"
+        macro:
+          email_format: "need to be a valid email"
+          login_format: "invalid login"
+          name_format: "must be between %{min} and %{max} characters"
+          password_format: "must be between %{min} and %{max} characters"
+          phone_format: "need to be a valid mobile number"
+        auction_context:
+          create:
+            finished_at: "must be after started time"

--- a/i18n/pt-BR/contracts/contracts.pt-BR.yml
+++ b/i18n/pt-BR/contracts/contracts.pt-BR.yml
@@ -60,9 +60,13 @@ pt-BR:
           password_confirmation: "não corresponde à senha"
           login_not_found: "Credenciais inválidas"
           inactive_account: "Sua conta está suspensa ou inativa"
+          future: "deve ser no futuro"
         macro:
           email_format: "não é um email válido"
           login_format: "login inválido"
           name_format: "deve ter entre %{min} e %{max} caracteres"
           password_format: "deve ter entre %{min} e %{max} caracteres"
           phone_format: "não é um número de celular válido"
+        auction_context:
+          create:
+            finished_at: "deve ser depois da hora de início"

--- a/lib/auction_fun_core/commands/auction_context/create_auction.rb
+++ b/lib/auction_fun_core/commands/auction_context/create_auction.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module AuctionFunCore
+  module Commands
+    module AuctionContext
+      ##
+      # Abstract base class for insert new tuples on auctions table.
+      # @abstract
+      class CreateAuction < ROM::Commands::Create[:sql]
+        relation :auctions
+        register_as :create
+        result :one
+
+        use :timestamps
+        timestamp :created_at, :updated_at
+      end
+    end
+  end
+end

--- a/lib/auction_fun_core/commands/auction_context/delete_auction.rb
+++ b/lib/auction_fun_core/commands/auction_context/delete_auction.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module AuctionFunCore
+  module Commands
+    module AuctionContext
+      ##
+      # Abstract base class for removes tuples in auctions table.
+      # @abstract
+      class DeleteAuction < ROM::Commands::Delete[:sql]
+        relation :auctions
+        register_as :delete
+      end
+    end
+  end
+end

--- a/lib/auction_fun_core/commands/auction_context/update_auction.rb
+++ b/lib/auction_fun_core/commands/auction_context/update_auction.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module AuctionFunCore
+  module Commands
+    module AuctionContext
+      ##
+      # Abstract base class for updates all tuples in its auctions table with new attributes
+      # @abstract
+      class UpdateAuction < ROM::Commands::Update[:sql]
+        relation :auctions
+        register_as :update
+
+        use :timestamps
+        timestamp :updated_at
+      end
+    end
+  end
+end

--- a/lib/auction_fun_core/contracts/auction_context/create_contract.rb
+++ b/lib/auction_fun_core/contracts/auction_context/create_contract.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+module AuctionFunCore
+  module Contracts
+    module AuctionContext
+      # Contract class to create new auctions.
+      class CreateContract < Contracts::ApplicationContract
+        KINDS = Relations::Auctions::KINDS.values
+        REQUIRED_FINISHED_AT = KINDS - ["penny"]
+        option :staff_repo, default: proc { Repos::StaffContext::StaffRepository.new }
+
+        # @param [Hash] opts Sets an allowed list of parameters, as well as some initial validations.
+        params do
+          required(:title).filled(:string, size?: (3..255))
+          required(:kind).value(included_in?: KINDS)
+          required(:started_at).filled(:time)
+          required(:staff_id).filled(:integer)
+          optional(:description)
+          optional(:finished_at).filled(:time)
+          optional(:initial_bid_cents).filled(:integer)
+          optional(:stopwatch).filled(:integer)
+
+          # Keys with a blank value are discarded.
+          before(:value_coercer) do |result|
+            result.to_h.compact
+          end
+
+          # By default, the minimum bid cents is initially equal to initial_bid_cents.
+          after(:value_coercer) do |result|
+            result.update(minimal_bid_cents: result[:initial_bid_cents]) if result[:initial_bid_cents]
+          end
+        end
+
+        # Validation for staff.
+        # Validate whether the given staff is valid at the database level.
+        rule(:staff_id) do |context:|
+          context[:staff] ||= staff_repo.by_id(value)
+          key.failure(I18n.t("contracts.errors.custom.default.not_found")) unless context[:staff]
+        end
+
+        # Validation for started_at.
+        # Validates if the entered date is greater than or equal to the current time.
+        rule(:started_at) do
+          key.failure(I18n.t("contracts.errors.custom.default.future")) if key? && value <= Time.current
+        end
+
+        # Specific validation when the auction type is informed and it is not penny,
+        # it must be mandatory to inform the auction closing date/time
+        rule(:finished_at, :kind) do
+          if key?(:kind) && !key?(:finished_at) && REQUIRED_FINISHED_AT.include?(values[:kind])
+            key.failure(I18n.t("contracts.errors.filled?"))
+          end
+        end
+
+        # Basic specific validation to check if the auction end time
+        # is less than or equal to the start time.
+        rule(:finished_at, :started_at) do
+          if key?(:finished_at) && (values[:finished_at] <= values[:started_at])
+            key.failure(I18n.t("contracts.errors.custom.auction_context.create.finished_at"))
+          end
+        end
+
+        # Validation for initial bid amount.
+        #
+        rule(:initial_bid_cents) do
+          # Must be filled if auction kind is not type penny.
+          key.failure(I18n.t("contracts.errors.filled?")) if !key? && REQUIRED_FINISHED_AT.include?(values[:kind])
+
+          # Must be greater than zero if action kind is not type penny.
+          if key? && REQUIRED_FINISHED_AT.include?(values[:kind]) && values[:initial_bid_cents] <= 0
+            key.failure(I18n.t("contracts.errors.gt?", num: 0))
+          end
+
+          # Must be equal to zero if auction kind is type penny.
+          if key? && values[:kind] == "penny" && !values[:initial_bid_cents].zero?
+            key.failure(I18n.t("contracts.errors.eql?", left: 0))
+          end
+        end
+
+        # Validation for stopwatch.
+        #
+        rule(:stopwatch) do
+          # Must be filled if auction kind is type penny.
+          key.failure(I18n.t("contracts.errors.filled?")) if !key? && values[:kind] == "penny"
+
+          # Must be an integer between 15 and 60.
+          if key? && values[:kind] == "penny" && !value.between?(15, 60)
+            key.failure(I18n.t("contracts.errors.included_in?.arg.range", list_left: 15, list_right: 60))
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/auction_fun_core/contracts/auction_context/create_contract.rb
+++ b/lib/auction_fun_core/contracts/auction_context/create_contract.rb
@@ -7,14 +7,19 @@ module AuctionFunCore
       class CreateContract < Contracts::ApplicationContract
         KINDS = Relations::Auctions::KINDS.values
         REQUIRED_FINISHED_AT = KINDS - ["penny"]
+        MIN_TITLE_LENGTH = 6
+        MAX_TITLE_LENGTH = 255
+        STOPWATCH_MIN_VALUE = 15
+        STOPWATCH_MAX_VALUE = 60
+
         option :staff_repo, default: proc { Repos::StaffContext::StaffRepository.new }
 
         # @param [Hash] opts Sets an allowed list of parameters, as well as some initial validations.
         params do
-          required(:title).filled(:string, size?: (3..255))
+          required(:staff_id).filled(:integer)
+          required(:title).filled(:string, size?: (MIN_TITLE_LENGTH..MAX_TITLE_LENGTH))
           required(:kind).value(included_in?: KINDS)
           required(:started_at).filled(:time)
-          required(:staff_id).filled(:integer)
           optional(:description)
           optional(:finished_at).filled(:time)
           optional(:initial_bid_cents).filled(:integer)
@@ -84,8 +89,13 @@ module AuctionFunCore
           key.failure(I18n.t("contracts.errors.filled?")) if !key? && values[:kind] == "penny"
 
           # Must be an integer between 15 and 60.
-          if key? && values[:kind] == "penny" && !value.between?(15, 60)
-            key.failure(I18n.t("contracts.errors.included_in?.arg.range", list_left: 15, list_right: 60))
+          if key? && values[:kind] == "penny" && !value.between?(STOPWATCH_MIN_VALUE, STOPWATCH_MAX_VALUE)
+            key.failure(
+              I18n.t(
+                "contracts.errors.included_in?.arg.range",
+                list_left: STOPWATCH_MIN_VALUE, list_right: STOPWATCH_MAX_VALUE
+              )
+            )
           end
         end
       end

--- a/lib/auction_fun_core/contracts/auction_context/processor/finish_contract.rb
+++ b/lib/auction_fun_core/contracts/auction_context/processor/finish_contract.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module AuctionFunCore
+  module Contracts
+    module AuctionContext
+      module Processor
+        ##
+        # Contract class for finish auctions.
+        #
+        class FinishContract < Contracts::ApplicationContract
+          option :auction_repo, default: proc { Repos::AuctionContext::AuctionRepository.new }
+
+          params do
+            required(:auction_id).filled(:integer)
+          end
+
+          # Validation for auction.
+          # Validates if the auction exists in the database.
+          rule(:auction_id) do |context:|
+            context[:auction] ||= auction_repo.by_id(value)
+            key.failure(I18n.t("contracts.errors.custom.not_found")) unless context[:auction]
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/auction_fun_core/contracts/auction_context/processor/start_contract.rb
+++ b/lib/auction_fun_core/contracts/auction_context/processor/start_contract.rb
@@ -8,6 +8,8 @@ module AuctionFunCore
         # Contract class for start auctions.
         #
         class StartContract < Contracts::ApplicationContract
+          STOPWATCH_MIN_VALUE = 15
+          STOPWATCH_MAX_VALUE = 60
           KINDS = Relations::Auctions::KINDS.values
           option :auction_repo, default: proc { Repos::AuctionContext::AuctionRepository.new }
 
@@ -31,8 +33,11 @@ module AuctionFunCore
             key.failure(I18n.t("contracts.errors.filled?")) if !key? && values[:kind] == "penny"
 
             # Must be an integer between 15 and 60.
-            if key? && values[:kind] == "penny" && !value.between?(15, 60)
-              key.failure(I18n.t("contracts.errors.included_in?.arg.range", list_left: 15, list_right: 60))
+            if key? && values[:kind] == "penny" && !value.between?(STOPWATCH_MIN_VALUE, STOPWATCH_MAX_VALUE)
+              key.failure(
+                I18n.t("contracts.errors.included_in?.arg.range",
+                  list_left: STOPWATCH_MIN_VALUE, list_right: STOPWATCH_MAX_VALUE)
+              )
             end
           end
         end

--- a/lib/auction_fun_core/contracts/auction_context/processor/start_contract.rb
+++ b/lib/auction_fun_core/contracts/auction_context/processor/start_contract.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module AuctionFunCore
+  module Contracts
+    module AuctionContext
+      module Processor
+        ##
+        # Contract class for start auctions.
+        #
+        class StartContract < Contracts::ApplicationContract
+          KINDS = Relations::Auctions::KINDS.values
+          option :auction_repo, default: proc { Repos::AuctionContext::AuctionRepository.new }
+
+          params do
+            required(:auction_id).filled(:integer)
+            required(:kind).value(included_in?: KINDS)
+            optional(:stopwatch).filled(:integer)
+          end
+
+          # Validation for auction.
+          # Validates if the auction exists in the database.
+          rule(:auction_id) do |context:|
+            context[:auction] ||= auction_repo.by_id(value)
+            key.failure(I18n.t("contracts.errors.custom.not_found")) unless context[:auction]
+          end
+
+          # Validation for stopwatch.
+          #
+          rule(:stopwatch) do
+            # Must be filled if auction kind is type penny.
+            key.failure(I18n.t("contracts.errors.filled?")) if !key? && values[:kind] == "penny"
+
+            # Must be an integer between 15 and 60.
+            if key? && values[:kind] == "penny" && !value.between?(15, 60)
+              key.failure(I18n.t("contracts.errors.included_in?.arg.range", list_left: 15, list_right: 60))
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/auction_fun_core/entities/auction.rb
+++ b/lib/auction_fun_core/entities/auction.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module AuctionFunCore
+  module Entities
+    # Auction Relations class. This return simple objects with attribute readers
+    # to represent data in your auction.
+    class Auction < ROM::Struct
+      def initial_bid
+        Money.new(initial_bid_cents, initial_bid_currency)
+      end
+
+      def minimal_bid
+        Money.new(minimal_bid_cents, minimal_bid_currency)
+      end
+    end
+  end
+end

--- a/lib/auction_fun_core/events/app.rb
+++ b/lib/auction_fun_core/events/app.rb
@@ -8,6 +8,10 @@ module AuctionFunCore
       # @!parser include Dry::Events::Publisher[:app]
       include Dry::Events::Publisher[:app]
 
+      register_event("auctions.created")
+      register_event("auctions.started")
+      register_event("auctions.finished")
+
       register_event("staffs.authentication")
       register_event("staffs.registration")
 

--- a/lib/auction_fun_core/events/listener.rb
+++ b/lib/auction_fun_core/events/listener.rb
@@ -5,6 +5,24 @@ module AuctionFunCore
     # Event class that can listen business events.
     # @see https://dry-rb.org/gems/dry-events/main/#event-listeners
     class Listener
+      # Listener for to *auctions.created* event.
+      # @param auction [ROM::Struct::Auction] the auction object
+      def on_auctions_created(auction)
+        logger("Create auction with: #{auction.to_h}")
+      end
+
+      # Listener for to *auctions.started* event.
+      # @param auction [ROM::Struct::Auction] the auction object
+      def on_auctions_started(auction)
+        logger("Started auction with: #{auction.to_h}")
+      end
+
+      # Listener for to *auctions.finished* event.
+      # @param auction [ROM::Struct::Auction] the auction object
+      def on_auctions_finished(auction)
+        logger("Finished auction: #{auction.to_h}")
+      end
+
       # Listener for to *staffs.authentication* event.
       # @param attributes [Hash] Authentication attributes
       # @option staff_id [Integer] Staff ID

--- a/lib/auction_fun_core/operations/auction_context/create_operation.rb
+++ b/lib/auction_fun_core/operations/auction_context/create_operation.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+module AuctionFunCore
+  module Operations
+    module AuctionContext
+      ##
+      # Operation class for creating auctions.
+      #
+      class CreateOperation < AuctionFunCore::Operations::Base
+        include Import["repos.auction_context.auction_repository"]
+        include Import["contracts.auction_context.create_contract"]
+        include Import["workers.operations.auction_context.processor.start_operation_job"]
+
+        # @todo Add custom doc
+        def self.call(attributes, &block)
+          operation = new.call(attributes)
+
+          return operation unless block
+
+          Dry::Matcher::ResultMatcher.call(operation, &block)
+        end
+
+        def call(attributes)
+          values = yield validate(attributes)
+
+          auction_repository.transaction do |_t|
+            @auction = yield persist(values)
+            yield scheduled_start_auction(@auction)
+            yield publish_auctions_created(@auction)
+          end
+
+          Success(@auction)
+        end
+
+        private
+
+        # Calls the auction creation contract class to perform the validation
+        # of the informed attributes.
+        # @param attrs [Hash] auction attributes
+        # @return [Dry::Monads::Result::Success, Dry::Monads::Result::Failure]
+        def validate(attrs)
+          contract = create_contract.call(attrs)
+
+          return Failure(contract.errors.to_h) if contract.failure?
+
+          Success(contract.to_h)
+        end
+
+        # Calls the auction repository class to persist the attributes in the database.
+        # @param result [Hash] Auction validated attributes
+        # @return [ROM::Struct::Auction]
+        def persist(result)
+          Success(auction_repository.create(result))
+        end
+
+        # Triggers the publication of event *auctions.created*.
+        # @param auction [Hash] Auction persisted attributes
+        # @return [Dry::Monads::Result::Success]
+        def publish_auctions_created(auction)
+          Application[:event].publish("auctions.created", auction.to_h)
+
+          Success()
+        end
+
+        # Calls the background job class that will schedule the start of the auction.
+        # Added a small delay to perform operations (such as sending broadcasts and/or other operations).
+        # @param auction [ROM::Struct::Auction]
+        # @return [String] sidekiq jid
+        def scheduled_start_auction(auction)
+          perform_at = auction.started_at
+
+          Success(start_operation_job.class.perform_at(perform_at, auction.id))
+        end
+      end
+    end
+  end
+end

--- a/lib/auction_fun_core/operations/auction_context/processor/finish_operation.rb
+++ b/lib/auction_fun_core/operations/auction_context/processor/finish_operation.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+module AuctionFunCore
+  module Operations
+    module AuctionContext
+      module Processor
+        ##
+        # Operation class for dispatch finish auction.
+        # By default, this change auction status from 'running' to 'finished'.
+        #
+        class FinishOperation < AuctionFunCore::Operations::Base
+          include Import["repos.auction_context.auction_repository"]
+          include Import["contracts.auction_context.processor.finish_contract"]
+
+          # @todo Add custom doc
+          def self.call(auction_id, &block)
+            operation = new.call(auction_id)
+
+            return operation unless block
+
+            Dry::Matcher::ResultMatcher.call(operation, &block)
+          end
+
+          # @todo Add more actions
+          #   Generate auction statistics and save in JSONB (statistics field)
+          #   Send email to winner with payment info.
+          #   Send email for bidders with user bid stats
+          def call(auction_id)
+            yield validate(auction_id: auction_id)
+
+            auction_repository.transaction do |_t|
+              @auction, _ = auction_repository.update(auction_id, status: "finished")
+
+              publish_auction_finish_event(@auction)
+            end
+
+            Success(@auction)
+          end
+
+          private
+
+          # Calls the finish contract class to perform the validation
+          # of the informed attributes.
+          # @param attributes [Hash] auction attributes
+          # @return [Dry::Monads::Result::Success, Dry::Monads::Result::Failure]
+          def validate(attributes)
+            contract = finish_contract.call(attributes)
+
+            return Failure(contract.errors.to_h) if contract.failure?
+
+            Success(contract.to_h)
+          end
+
+          def publish_auction_finish_event(auction)
+            Application[:event].publish("auctions.finished", auction.to_h)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/auction_fun_core/operations/auction_context/processor/start_operation.rb
+++ b/lib/auction_fun_core/operations/auction_context/processor/start_operation.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+module AuctionFunCore
+  module Operations
+    module AuctionContext
+      module Processor
+        ##
+        # Operation class for dispatch start auction.
+        # By default, this change auction status from 'scheduled' to 'running'
+        # and schedule a job to execute the auction finalization when auction is not penny.
+        class StartOperation < AuctionFunCore::Operations::Base
+          include Import["repos.auction_context.auction_repository"]
+          include Import["contracts.auction_context.processor.start_contract"]
+          include Import["workers.operations.auction_context.processor.finish_operation_job"]
+
+          # @todo Add custom doc
+          def self.call(attributes, &block)
+            operation = new.call(attributes)
+
+            return operation unless block
+
+            Dry::Matcher::ResultMatcher.call(operation, &block)
+          end
+
+          # @param [Hash] attributes needed to start a auction
+          # @option opts [String] :auction_id auction id
+          # @option opts [String] :auction_kind auction kind
+          # @option opts [Integer] :stopwatch auction stopwatch
+          # @return [ROM::Struct::Auction] auction object
+          def call(attributes)
+            attrs = yield validate(attributes)
+
+            auction_repository.transaction do |_t|
+              @auction, _ = auction_repository.update(attrs[:auction_id], update_params(attrs))
+
+              yield publish_auction_start_event(@auction)
+              yield scheduled_finished_auction(@auction)
+            end
+
+            Success(@auction)
+          end
+
+          private
+
+          # Calls the start contract class to perform the validation
+          # of the informed attributes.
+          # @param attributes [Hash] auction attributes
+          # @return [Dry::Monads::Result::Success, Dry::Monads::Result::Failure]
+          def validate(attributes)
+            contract = start_contract.call(attributes)
+
+            return Failure(contract.errors.to_h) if contract.failure?
+
+            Success(contract.to_h)
+          end
+
+          # Updates the status of the auction and depending on the type of auction,
+          # it already sets the final date.
+          # @param attrs [Hash] auction attributes
+          # @return [Hash]
+          def update_params(attrs)
+            return {status: "running"} unless attrs[:kind] == "penny"
+
+            {status: "running", finished_at: attrs[:stopwatch].seconds.from_now}
+          end
+
+          def publish_auction_start_event(auction)
+            Success(Application[:event].publish("auctions.started", auction.to_h))
+          end
+
+          # Calls the background job class that will schedule the finish of the auction.
+          # Added a small delay to perform operations (such as sending broadcasts and/or other operations).
+          # @param auction [ROM::Struct::Auction]
+          # @return [String] sidekiq jid
+          def scheduled_finished_auction(auction)
+            return Success() if auction.kind == "penny"
+
+            Success(finish_operation_job.class.perform_at(auction.finished_at, auction.id))
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/auction_fun_core/relations/auctions.rb
+++ b/lib/auction_fun_core/relations/auctions.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module AuctionFunCore
+  module Relations
+    # SQL relation for auctions.
+    # @see https://rom-rb.org/5.0/learn/sql/relations/
+    class Auctions < ROM::Relation[:sql]
+      use :pagination, per_page: 10
+
+      KINDS = Types::Coercible::String.default("standard").enum("standard", "penny", "closed")
+      STATUSES = Types::Coercible::String.default("scheduled")
+        .enum("scheduled", "running", "paused", "canceled", "finished")
+
+      schema(:auctions, infer: true) do
+        attribute :id, Types::Integer
+        attribute :staff_id, Types::ForeignKey(:staffs)
+        attribute :title, Types::String
+        attribute :description, Types::String
+        attribute :kind, KINDS
+        attribute :status, STATUSES
+        attribute :started_at, Types::DateTime
+        attribute :finished_at, Types::DateTime
+        attribute :stopwatch, Types::Integer
+        attribute :initial_bid_cents, Types::Integer
+        attribute :initial_bid_currency, Types::String
+        attribute :minimal_bid_cents, Types::Integer
+        attribute :minimal_bid_currency, Types::String
+
+        attribute :metadata, Types::PG::JSONB
+        attribute :statistics, Types::PG::JSONB
+        primary_key :id
+
+        associations do
+          belongs_to :staff, as: :staff, relation: :staffs
+        end
+      end
+
+      struct_namespace Entities
+      auto_struct(true)
+    end
+  end
+end

--- a/lib/auction_fun_core/repos/auction_context/auction_repository.rb
+++ b/lib/auction_fun_core/repos/auction_context/auction_repository.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module AuctionFunCore
+  module Repos
+    module AuctionContext
+      # SQL repository for auctions.
+      class AuctionRepository < ROM::Repository[:auctions]
+        include Import["container"]
+
+        struct_namespace Entities
+        commands :create, update: :by_pk, delete: :by_pk
+
+        # Returns the total number of auctions in database.
+        # @return [Integer]
+        def count
+          auctions.count
+        end
+
+        # Search auction in database by primary key.
+        # @param id [Integer] Auction ID
+        # @return [ROM::Struct::Auction, nil]
+        def by_id(id)
+          auctions.by_pk(id).one
+        end
+
+        # Search auction in database by primary key.
+        # @param id [Integer] Auction ID
+        # @raise [ROM::TupleCountMismatchError] if not found on database
+        # @return [ROM::Struct::Auction]
+        def by_id!(id)
+          auctions.by_pk(id).one!
+        end
+      end
+    end
+  end
+end

--- a/lib/auction_fun_core/version.rb
+++ b/lib/auction_fun_core/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module AuctionFunCore
-  VERSION = "0.6.1"
+  VERSION = "0.7.0"
 
   # Required class module is a gem dependency
   class Version; end

--- a/lib/auction_fun_core/workers/operations/auction_context/processor/finish_operation_job.rb
+++ b/lib/auction_fun_core/workers/operations/auction_context/processor/finish_operation_job.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module AuctionFunCore
+  module Workers
+    module Operations
+      module AuctionContext
+        module Processor
+          ##
+          # BackgroundJob class for call finish auction operation.
+          #
+          class FinishOperationJob < Workers::ApplicationJob
+            include Import["repos.auction_context.auction_repository"]
+            include Import["operations.auction_context.processor.finish_operation"]
+
+            # @todo Add detailed documentation
+            def perform(auction_id, retry_count = 0)
+              auction = auction_repository.by_id!(auction_id)
+
+              finish_operation.call(auction.id)
+            rescue => e
+              capture_exception(e, {auction_id: auction_id, retry_count: retry_count})
+              raise if retry_count >= MAX_RETRIES
+
+              interval = backoff_exponential_job(retry_count)
+              self.class.perform_at(interval, auction_id, retry_count + 1)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/auction_fun_core/workers/operations/auction_context/processor/start_operation_job.rb
+++ b/lib/auction_fun_core/workers/operations/auction_context/processor/start_operation_job.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module AuctionFunCore
+  module Workers
+    module Operations
+      module AuctionContext
+        module Processor
+          ##
+          # BackgroundJob class for call start auction operation.
+          #
+          class StartOperationJob < AuctionFunCore::Workers::ApplicationJob
+            include Import["repos.auction_context.auction_repository"]
+            include Import["operations.auction_context.processor.start_operation"]
+
+            # @todo Add detailed documentation
+            def perform(auction_id, retry_count = 0)
+              auction = auction_repository.by_id!(auction_id)
+
+              start_operation.call(auction_id: auction.id, kind: auction.kind, stopwatch: auction.stopwatch)
+            rescue => e
+              capture_exception(e, {auction_id: auction_id, retry_count: retry_count})
+              raise if retry_count >= MAX_RETRIES
+
+              interval = backoff_exponential_job(retry_count)
+              self.class.perform_at(interval, auction_id, retry_count + 1)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/auction_fun_core/contracts/auction_context/create_contract_spec.rb
+++ b/spec/auction_fun_core/contracts/auction_context/create_contract_spec.rb
@@ -1,0 +1,145 @@
+# frozen_string_literal: true
+
+RSpec.describe AuctionFunCore::Contracts::AuctionContext::CreateContract, type: :contract do
+  describe "#call" do
+    subject(:contract) { described_class.new.call(attributes) }
+
+    context "when params are blank" do
+      let(:attributes) { Dry::Core::Constants::EMPTY_HASH }
+
+      it "expect failure with error messages" do
+        expect(contract).to be_failure
+
+        expect(contract.errors[:title]).to include(I18n.t("contracts.errors.key?"))
+        expect(contract.errors[:kind]).to include(I18n.t("contracts.errors.key?"))
+        expect(contract.errors[:started_at]).to include(I18n.t("contracts.errors.key?"))
+        expect(contract.errors[:staff_id]).to include(I18n.t("contracts.errors.key?"))
+      end
+    end
+
+    context "with default values" do
+      let(:attributes) { {initial_bid_cents: 100} }
+
+      it "expect minimal_bid_cents to be equal initial_bid_cents" do
+        expect(contract[:minimal_bid_cents]).to eq(100)
+      end
+    end
+
+    describe "#staff_id" do
+      context "when staff is not found on database" do
+        let(:attributes) { {staff_id: 1} }
+
+        it "expect failure with error messages" do
+          expect(contract).to be_failure
+          expect(contract.errors[:staff_id])
+            .to include(I18n.t("contracts.errors.custom.default.not_found"))
+        end
+      end
+    end
+
+    describe "#started_at" do
+      context "when is less than or equal to now" do
+        let(:attributes) { {started_at: 3.days.ago} }
+
+        it "expect failure with error messages" do
+          expect(contract).to be_failure
+          expect(contract.errors[:started_at])
+            .to include(I18n.t("contracts.errors.custom.default.future"))
+        end
+      end
+    end
+
+    describe "#kind" do
+      context "when kind is standard or closed and finished_at is blank" do
+        let(:attributes) { {kind: "standard", started_at: 3.hours.from_now} }
+
+        it "expect failure with error messages" do
+          expect(contract).to be_failure
+          expect(contract.errors[:finished_at]).to include(I18n.t("contracts.errors.filled?"))
+        end
+      end
+
+      context "when kind is closed and finished_at is blank" do
+        let(:attributes) { {kind: "closed", started_at: 3.hours.from_now} }
+
+        it "expect failure with error messages" do
+          expect(contract).to be_failure
+          expect(contract.errors[:finished_at]).to include(I18n.t("contracts.errors.filled?"))
+        end
+      end
+    end
+
+    describe "#finished_at" do
+      context "when started_at is less than or equal to finished_at" do
+        let(:same_time) { 3.hours.from_now }
+        let(:attributes) { {kind: "standard", started_at: same_time, finished_at: same_time} }
+
+        it "expect failure with error messages" do
+          expect(contract).to be_failure
+          expect(contract.errors[:finished_at])
+            .to include(I18n.t("contracts.errors.custom.auction_context.create.finished_at"))
+        end
+      end
+    end
+
+    describe "#initial_bid_cents" do
+      context "when kind is standard or closed and initial_bid_cents is blank" do
+        let(:attributes) { {kind: "standard"} }
+
+        it "expect failure with error messages" do
+          expect(contract).to be_failure
+          expect(contract.errors[:initial_bid_cents]).to include(I18n.t("contracts.errors.filled?"))
+        end
+      end
+
+      context "when kind is standard or closed and initial_bid_cents is less than or equal to zero" do
+        let(:attributes) { {kind: "standard", initial_bid_cents: 0} }
+
+        it "expect failure with error messages" do
+          expect(contract).to be_failure
+          expect(contract.errors[:initial_bid_cents]).to include(I18n.t("contracts.errors.gt?", num: 0))
+        end
+      end
+
+      context "when kind is penny and initial_bid_cents is blank" do
+        let(:attributes) { {kind: "penny"} }
+
+        it "expect failure without error message in field" do
+          expect(contract).to be_failure
+          expect(contract.errors[:initial_bid_cents]).to be_blank
+        end
+      end
+
+      context "when kind is penny and initial_bid_cents is not zero" do
+        let(:attributes) { {kind: "penny", initial_bid_cents: 1000} }
+
+        it "expect failure with error message" do
+          expect(contract).to be_failure
+          expect(contract.errors[:initial_bid_cents]).to include(I18n.t("contracts.errors.eql?", left: 0))
+        end
+      end
+    end
+
+    describe "stopwatch" do
+      context "when kind is penny and stopwatch is blank" do
+        let(:attributes) { {kind: "penny", initial_bid_cents: 1000} }
+
+        it "expect failure with error message" do
+          expect(contract).to be_failure
+          expect(contract.errors[:stopwatch]).to include(I18n.t("contracts.errors.filled?"))
+        end
+      end
+
+      context "when kind is penny and stopwatch is not within the allowed range" do
+        let(:attributes) { {kind: "penny", initial_bid_cents: 1000, stopwatch: 100} }
+
+        it "expect failure with error message" do
+          expect(contract).to be_failure
+          expect(contract.errors[:stopwatch]).to include(
+            I18n.t("contracts.errors.included_in?.arg.range", list_left: 15, list_right: 60)
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/auction_fun_core/contracts/auction_context/processor/finish_contract_spec.rb
+++ b/spec/auction_fun_core/contracts/auction_context/processor/finish_contract_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+RSpec.describe AuctionFunCore::Contracts::AuctionContext::Processor::FinishContract, type: :contract do
+  let(:auction) { Factory[:auction, :default_running_standard] }
+
+  describe "#call" do
+    subject(:contract) { described_class.new.call(attributes) }
+
+    context "when attributes are invalid" do
+      let(:attributes) { Dry::Core::Constants::EMPTY_HASH }
+
+      it "expect failure with error messages" do
+        expect(contract).to be_failure
+        expect(contract.errors[:auction_id]).to include(I18n.t("contracts.errors.key?"))
+      end
+    end
+
+    context "when attributes are valid" do
+      let(:attributes) { {auction_id: auction.id} }
+
+      it "expect return success" do
+        expect(contract).to be_success
+        expect(contract.context[:auction]).to be_a(AuctionFunCore::Entities::Auction)
+      end
+    end
+  end
+end

--- a/spec/auction_fun_core/contracts/auction_context/processor/start_contract_spec.rb
+++ b/spec/auction_fun_core/contracts/auction_context/processor/start_contract_spec.rb
@@ -2,6 +2,7 @@
 
 RSpec.describe AuctionFunCore::Contracts::AuctionContext::Processor::StartContract, type: :contract do
   let(:auction) { Factory[:auction, :default_standard] }
+  let(:kinds) { described_class::KINDS.join(", ") }
 
   describe "#call" do
     subject(:contract) { described_class.new.call(attributes) }
@@ -14,6 +15,10 @@ RSpec.describe AuctionFunCore::Contracts::AuctionContext::Processor::StartContra
         expect(contract.errors[:auction_id]).to include(I18n.t("contracts.errors.key?"))
         expect(contract.errors[:kind]).to include(I18n.t("contracts.errors.key?"))
       end
+    end
+
+    it_behaves_like "validate_stopwatch_contract" do
+      let(:auction) { Factory[:auction, :default_penny] }
     end
 
     context "when auction_id is not founded on database" do
@@ -31,35 +36,8 @@ RSpec.describe AuctionFunCore::Contracts::AuctionContext::Processor::StartContra
       it "expect failure with error messages" do
         expect(contract).to be_failure
         expect(contract.errors[:kind]).to include(
-          I18n.t(
-            "contracts.errors.included_in?.arg.default",
-            list: described_class::KINDS.join(", ")
-          )
+          I18n.t("contracts.errors.included_in?.arg.default", list: kinds)
         )
-      end
-    end
-
-    describe "stopwatch" do
-      let(:auction) { Factory[:auction, :default_penny] }
-
-      context "when kind is penny and stopwatch is blank" do
-        let(:attributes) { {auction_id: auction.id, kind: auction.kind} }
-
-        it "expect failure with error message" do
-          expect(contract).to be_failure
-          expect(contract.errors[:stopwatch]).to include(I18n.t("contracts.errors.filled?"))
-        end
-      end
-
-      context "when kind is penny and stopwatch is not within the allowed range" do
-        let(:attributes) { {auction_id: auction.id, kind: auction.kind, stopwatch: 100} }
-
-        it "expect failure with error message" do
-          expect(contract).to be_failure
-          expect(contract.errors[:stopwatch]).to include(
-            I18n.t("contracts.errors.included_in?.arg.range", list_left: 15, list_right: 60)
-          )
-        end
       end
     end
 

--- a/spec/auction_fun_core/contracts/auction_context/processor/start_contract_spec.rb
+++ b/spec/auction_fun_core/contracts/auction_context/processor/start_contract_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+RSpec.describe AuctionFunCore::Contracts::AuctionContext::Processor::StartContract, type: :contract do
+  let(:auction) { Factory[:auction, :default_standard] }
+
+  describe "#call" do
+    subject(:contract) { described_class.new.call(attributes) }
+
+    context "when all attributes are blank" do
+      let(:attributes) { Dry::Core::Constants::EMPTY_HASH }
+
+      it "expect failure with error messages" do
+        expect(contract).to be_failure
+        expect(contract.errors[:auction_id]).to include(I18n.t("contracts.errors.key?"))
+        expect(contract.errors[:kind]).to include(I18n.t("contracts.errors.key?"))
+      end
+    end
+
+    context "when auction_id is not founded on database" do
+      let(:attributes) { {auction_id: 2_234_231} }
+
+      it "expect failure with error messages" do
+        expect(contract).to be_failure
+        expect(contract.errors[:auction_id]).to include(I18n.t("contracts.errors.custom.not_found"))
+      end
+    end
+
+    describe "when auction kind is invalid" do
+      let(:attributes) { {auction_id: auction.id, auction: "invalid"} }
+
+      it "expect failure with error messages" do
+        expect(contract).to be_failure
+        expect(contract.errors[:kind]).to include(
+          I18n.t(
+            "contracts.errors.included_in?.arg.default",
+            list: described_class::KINDS.join(", ")
+          )
+        )
+      end
+    end
+
+    describe "stopwatch" do
+      let(:auction) { Factory[:auction, :default_penny] }
+
+      context "when kind is penny and stopwatch is blank" do
+        let(:attributes) { {auction_id: auction.id, kind: auction.kind} }
+
+        it "expect failure with error message" do
+          expect(contract).to be_failure
+          expect(contract.errors[:stopwatch]).to include(I18n.t("contracts.errors.filled?"))
+        end
+      end
+
+      context "when kind is penny and stopwatch is not within the allowed range" do
+        let(:attributes) { {auction_id: auction.id, kind: auction.kind, stopwatch: 100} }
+
+        it "expect failure with error message" do
+          expect(contract).to be_failure
+          expect(contract.errors[:stopwatch]).to include(
+            I18n.t("contracts.errors.included_in?.arg.range", list_left: 15, list_right: 60)
+          )
+        end
+      end
+    end
+
+    context "when attributes are valid" do
+      let(:attributes) { {auction_id: auction.id, kind: auction.kind, stopwatch: 15} }
+
+      it "expect return success" do
+        expect(contract).to be_success
+        expect(contract.context[:auction]).to be_a(AuctionFunCore::Entities::Auction)
+      end
+    end
+  end
+end

--- a/spec/auction_fun_core/entities/auction_spec.rb
+++ b/spec/auction_fun_core/entities/auction_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe AuctionFunCore::Entities::Auction, type: :entity do
+  describe "#initial_bid" do
+    subject(:auction) { Factory.structs[:auction] }
+
+    it "expect return initial bid as money object" do
+      expect(auction.initial_bid).to be_a_instance_of(Money)
+    end
+  end
+
+  describe "#minimal_bid" do
+    subject(:auction) { Factory.structs[:auction] }
+
+    it "expect return minimal bid as money object" do
+      expect(auction.minimal_bid).to be_a_instance_of(Money)
+    end
+  end
+end

--- a/spec/auction_fun_core/operations/auction_context/create_operation_spec.rb
+++ b/spec/auction_fun_core/operations/auction_context/create_operation_spec.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe AuctionFunCore::Operations::AuctionContext::CreateOperation, type: :operation do
+  let(:auction_repository) { AuctionFunCore::Repos::AuctionContext::AuctionRepository.new }
+
+  describe ".call(attributes, &block)" do
+    let(:operation) { described_class }
+
+    context "when block is given" do
+      context "when operation happens with success" do
+        let(:staff) { Factory[:staff] }
+        let(:attributes) do
+          Factory.structs[:auction, :default_standard, staff: staff]
+            .to_h.except(:id, :created_at, :updated_at, :staff)
+        end
+
+        it "expect result success matching block" do
+          matched_success = nil
+          matched_failure = nil
+
+          operation.call(attributes) do |o|
+            o.success { |v| matched_success = v }
+            o.failure { |f| matched_failure = f }
+          end
+
+          expect(matched_success).to be_a(AuctionFunCore::Entities::Auction)
+          expect(matched_failure).to be_nil
+        end
+      end
+
+      context "when operation happens with failure" do
+        let(:attributes) { Dry::Core::Constants::EMPTY_HASH }
+
+        it "expect result matching block" do
+          matched_success = nil
+          matched_failure = nil
+
+          operation.call(attributes) do |o|
+            o.success { |v| matched_success = v }
+            o.failure { |f| matched_failure = f }
+          end
+
+          expect(matched_success).to be_nil
+          expect(matched_failure[:title]).to include(I18n.t("contracts.errors.key?"))
+        end
+      end
+    end
+  end
+
+  describe "#call" do
+    subject(:operation) { described_class.new.call(attributes) }
+
+    context "when contract are invalid" do
+      let(:attributes) { Dry::Core::Constants::EMPTY_HASH }
+
+      it "expect not persist new auction on database" do
+        expect(auction_repository.count).to be_zero
+
+        expect { operation }.not_to change(auction_repository, :count)
+      end
+
+      it "expect return failure with error messages" do
+        expect(operation).to be_failure
+        expect(operation.failure[:title]).to include(I18n.t("contracts.errors.key?"))
+      end
+    end
+
+    context "when contract are valid" do
+      let(:staff) { Factory[:staff] }
+      let(:attributes) do
+        Factory.structs[:auction, :default_standard, staff: staff]
+          .to_h.except(:id, :created_at, :updated_at, :staff)
+      end
+
+      before do
+        allow(AuctionFunCore::Application[:event]).to receive(:publish)
+        allow(AuctionFunCore::Workers::Operations::AuctionContext::Processor::StartOperationJob)
+          .to receive(:perform_at)
+      end
+
+      it "expect return success" do
+        expect(operation).to be_success
+        expect(operation.failure).to be_nil
+      end
+
+      it "expect create auction on database with correct status and dispatch event and processes" do
+        expect { operation }.to change(auction_repository, :count).from(0).to(1)
+
+        expect(operation.success.status).to eq("scheduled")
+        expect(AuctionFunCore::Application[:event]).to have_received(:publish).once
+        expect(AuctionFunCore::Workers::Operations::AuctionContext::Processor::StartOperationJob)
+          .to have_received(:perform_at).once
+      end
+    end
+  end
+end

--- a/spec/auction_fun_core/operations/auction_context/processor/finish_operation_spec.rb
+++ b/spec/auction_fun_core/operations/auction_context/processor/finish_operation_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe AuctionFunCore::Operations::AuctionContext::Processor::FinishOperation, type: :operation do
+  let(:auction_repository) { AuctionFunCore::Repos::AuctionContext::AuctionRepository.new }
+  let(:auction) { Factory[:auction, :default_running_standard, finished_at: Time.current] }
+
+  describe ".call(auction_id, &block)" do
+    let(:operation) { described_class }
+
+    context "when block is given" do
+      context "when operation happens with success" do
+        it "expect result success matching block" do
+          matched_success = nil
+          matched_failure = nil
+
+          operation.call(auction.id) do |o|
+            o.success { |v| matched_success = v }
+            o.failure { |f| matched_failure = f }
+          end
+
+          expect(matched_success.id).to eq(auction.id)
+          expect(matched_success.status).to eq("finished")
+          expect(matched_failure).to be_nil
+        end
+      end
+
+      context "when operation happens with failure" do
+        let(:auction_id) { nil }
+
+        it "expect result matching block" do
+          matched_success = nil
+          matched_failure = nil
+
+          operation.call(auction_id) do |o|
+            o.success { |v| matched_success = v }
+            o.failure { |f| matched_failure = f }
+          end
+
+          expect(matched_success).to be_nil
+          expect(matched_failure[:auction_id]).to include(I18n.t("contracts.errors.filled?"))
+        end
+      end
+    end
+  end
+
+  describe "#call" do
+    subject(:operation) { described_class.new.call(auction_id) }
+
+    context "when contract is invalid" do
+      let(:auction_id) { nil }
+
+      it "expect not change auction status" do
+        expect { operation }.not_to change { auction_repository.by_id(auction.id).status }
+      end
+
+      it "expect return failure with error messages" do
+        expect(operation.failure[:auction_id]).to include(I18n.t("contracts.errors.filled?"))
+      end
+    end
+
+    context "when contract is valid" do
+      let(:auction_id) { auction.id }
+
+      it "expect update status auction record on database" do
+        expect { operation }
+          .to change { auction_repository.by_id(auction.id).status }
+          .from("running")
+          .to("finished")
+      end
+
+      it "expect publish the auction finish event" do
+        allow(AuctionFunCore::Application[:event]).to receive(:publish)
+
+        operation
+
+        expect(AuctionFunCore::Application[:event]).to have_received(:publish).once
+      end
+    end
+  end
+end

--- a/spec/auction_fun_core/operations/auction_context/processor/start_operation_spec.rb
+++ b/spec/auction_fun_core/operations/auction_context/processor/start_operation_spec.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe AuctionFunCore::Operations::AuctionContext::Processor::StartOperation, type: :operation do
+  let(:auction_repository) { AuctionFunCore::Repos::AuctionContext::AuctionRepository.new }
+  let(:auction) { Factory[:auction, :default_standard, started_at: Time.current] }
+  let(:auction_id) { auction.id }
+  let(:kind) { auction.kind }
+  let(:stopwatch) { 0 }
+
+  describe ".call(attributes, &block)" do
+    let(:operation) { described_class }
+
+    context "when block is given" do
+      context "when operation happens with success" do
+        let(:attributes) do
+          {
+            auction_id: auction.id,
+            kind: auction.kind,
+            stopwatch: auction.stopwatch
+          }
+        end
+
+        it "expect result success matching block" do
+          matched_success = nil
+          matched_failure = nil
+
+          operation.call(attributes) do |o|
+            o.success { |v| matched_success = v }
+            o.failure { |f| matched_failure = f }
+          end
+
+          expect(matched_success.id).to eq(auction.id)
+          expect(matched_success.status).to eq("running")
+          expect(matched_failure).to be_nil
+        end
+      end
+
+      context "when operation happens with failure" do
+        let(:attributes) { Dry::Core::Constants::EMPTY_HASH }
+
+        it "expect result matching block" do
+          matched_success = nil
+          matched_failure = nil
+
+          operation.call(attributes) do |o|
+            o.success { |v| matched_success = v }
+            o.failure { |f| matched_failure = f }
+          end
+
+          expect(matched_success).to be_nil
+          expect(matched_failure[:auction_id]).to include(I18n.t("contracts.errors.key?"))
+        end
+      end
+    end
+  end
+
+  describe "#call" do
+    subject(:operation) { described_class.new.call(attributes) }
+
+    context "when contract is invalid" do
+      let(:attributes) { Dry::Core::Constants::EMPTY_HASH }
+
+      it "expect not change auction status" do
+        expect { operation }.not_to change { auction_repository.by_id(auction.id).status }
+      end
+    end
+
+    context "when contract is valid" do
+      let(:attributes) do
+        {
+          auction_id: auction.id,
+          kind: auction.kind,
+          stopwatch: auction.stopwatch
+        }
+      end
+
+      it "expect update status auction record on database" do
+        expect { operation }.to change { auction_repository.by_id(auction.id).status }.from("scheduled").to("running")
+      end
+
+      it "expect create a new job to finish the auction" do
+        allow(AuctionFunCore::Workers::Operations::AuctionContext::Processor::FinishOperationJob).to receive(:perform_at)
+
+        operation
+
+        expect(AuctionFunCore::Workers::Operations::AuctionContext::Processor::FinishOperationJob)
+          .to have_received(:perform_at)
+          .with(auction.finished_at, auction.id)
+          .once
+      end
+
+      it "expect publish the auction start event" do
+        allow(AuctionFunCore::Application[:event]).to receive(:publish)
+
+        operation
+
+        expect(AuctionFunCore::Application[:event]).to have_received(:publish).once
+      end
+
+      context "when auction kind is penny" do
+        let(:stopwatch) { 45 }
+        let(:old_finished_at) { auction.finished_at.strftime("%Y-%m-%d %H:%M:%S") }
+        let(:new_finished_at) { stopwatch.seconds.from_now.strftime("%Y-%m-%d %H:%M:%S") }
+        let(:attributes) do
+          {
+            auction_id: auction.id,
+            kind: "penny",
+            stopwatch: stopwatch
+          }
+        end
+
+        before { auction_repository.update(auction.id, kind: "penny") }
+
+        it "expect update finished_at to stopwatch seconds from now" do
+          expect { operation }
+            .to change { auction_repository.by_id(auction.id).finished_at.strftime("%Y-%m-%d %H:%M:%S") }
+            .from(old_finished_at)
+            .to(new_finished_at)
+        end
+      end
+    end
+  end
+end

--- a/spec/auction_fun_core/workers/operations/auction_context/processor/finish_operation_job_spec.rb
+++ b/spec/auction_fun_core/workers/operations/auction_context/processor/finish_operation_job_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe AuctionFunCore::Workers::Operations::AuctionContext::Processor::FinishOperationJob, type: :worker do
+  let(:auction_repository) { AuctionFunCore::Repos::AuctionContext::AuctionRepository.new }
+  let(:auction) { Factory[:auction, :default_running_standard] }
+
+  describe "#perform" do
+    subject(:worker) { described_class.new }
+
+    context "when params are valid" do
+      it "expect execute auction start operation" do
+        expect { worker.perform(auction.id) }
+          .to change { auction_repository.by_id(auction.id).status }
+          .from("running")
+          .to("finished")
+      end
+    end
+
+    context "when an exception occours but retry limit is not reached" do
+      before do
+        stub_const("::AuctionFunCore::Workers::ApplicationJob::MAX_RETRIES", 1)
+        allow(AuctionFunCore::Application[:logger]).to receive(:error)
+      end
+
+      it "expect rescue/capture exception and reschedule job" do
+        expect { worker.perform(nil) }.to change(described_class.jobs, :size).from(0).to(1)
+
+        expect(AuctionFunCore::Application[:logger]).to have_received(:error).at_least(:once)
+      end
+    end
+
+    context "when the exception reaches the retry limit" do
+      before do
+        stub_const("::AuctionFunCore::Workers::ApplicationJob::MAX_RETRIES", 0)
+        allow(AuctionFunCore::Application[:logger]).to receive(:error)
+      end
+
+      it "expect raise exception and stop retry" do
+        expect { worker.perform(nil) }.to raise_error(ROM::TupleCountMismatchError)
+
+        expect(AuctionFunCore::Application[:logger]).to have_received(:error).at_least(:once)
+      end
+    end
+  end
+end

--- a/spec/auction_fun_core/workers/operations/auction_context/processor/start_operation_job_spec.rb
+++ b/spec/auction_fun_core/workers/operations/auction_context/processor/start_operation_job_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe AuctionFunCore::Workers::Operations::AuctionContext::Processor::StartOperationJob, type: :worker do
+  let(:auction_repository) { AuctionFunCore::Repos::AuctionContext::AuctionRepository.new }
+  let(:auction) { Factory[:auction, :default_standard] }
+
+  describe "#perform" do
+    subject(:worker) { described_class.new }
+
+    context "when params are valid" do
+      it "expect execute auction start operation" do
+        expect { worker.perform(auction.id) }
+          .to change { auction_repository.by_id(auction.id).status }
+          .from("scheduled")
+          .to("running")
+      end
+    end
+
+    context "when an exception occours but retry limit is not reached" do
+      before do
+        stub_const("::AuctionFunCore::Workers::ApplicationJob::MAX_RETRIES", 1)
+        allow(AuctionFunCore::Application[:logger]).to receive(:error)
+      end
+
+      it "expect rescue/capture exception and reschedule job" do
+        expect { worker.perform(nil) }.to change(described_class.jobs, :size).from(0).to(1)
+
+        expect(AuctionFunCore::Application[:logger]).to have_received(:error).at_least(:once)
+      end
+    end
+
+    context "when the exception reaches the retry limit" do
+      before do
+        stub_const("::AuctionFunCore::Workers::ApplicationJob::MAX_RETRIES", 0)
+        allow(AuctionFunCore::Application[:logger]).to receive(:error)
+      end
+
+      it "expect raise exception and stop retry" do
+        expect { worker.perform(nil) }.to raise_error(ROM::TupleCountMismatchError)
+
+        expect(AuctionFunCore::Application[:logger]).to have_received(:error).at_least(:once)
+      end
+    end
+  end
+end

--- a/spec/auction_fun_core_spec.rb
+++ b/spec/auction_fun_core_spec.rb
@@ -2,6 +2,6 @@
 
 RSpec.describe AuctionFunCore do
   it "has a version number" do
-    expect(AuctionFunCore::VERSION).to eq("0.6.1")
+    expect(AuctionFunCore::VERSION).to eq("0.7.0")
   end
 end

--- a/spec/support/factories/auctions.rb
+++ b/spec/support/factories/auctions.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+Factory.define(:auction, struct_namespace: AuctionFunCore::Entities) do |f|
+  f.association(:staff)
+  f.title { fake(:commerce, :product_name) }
+  f.description { fake(:lorem, :paragraph) }
+  f.initial_bid_cents { 0 }
+  f.initial_bid_currency { AuctionFunCore::Application[:settings].default_currency }
+  f.minimal_bid_cents { 0 }
+  f.minimal_bid_currency { AuctionFunCore::Application[:settings].default_currency }
+
+  f.trait :with_minimal_bid do |t|
+  end
+
+  f.trait :with_kind_standard do |t|
+    t.kind { "standard" }
+  end
+
+  f.trait :with_kind_penny do |t|
+    t.kind { "penny" }
+  end
+
+  f.trait :with_kind_closed do |t|
+    t.kind { "closed" }
+  end
+
+  f.trait :with_status_scheduled do |t|
+    t.status { "scheduled" }
+  end
+
+  f.trait :with_status_running do |t|
+    t.status { "running" }
+  end
+
+  f.trait :with_status_paused do |t|
+    t.status { "paused" }
+  end
+
+  f.trait :with_status_canceled do |t|
+    t.status { "canceled" }
+  end
+
+  f.trait :with_status_finished do |t|
+    t.status { "finished" }
+  end
+
+  f.trait :started_in_one_hour_from_now do |t|
+    t.started_at { 1.hour.from_now }
+  end
+
+  f.trait :started_in_one_day_from_now do |t|
+    t.started_at { 1.day.from_now }
+  end
+
+  f.trait :finished_in_two_days_from_now do |t|
+    t.started_at { 1.day.from_now }
+    t.finished_at { 2.days.from_now }
+  end
+
+  f.trait :default_standard do |t|
+    t.kind { "standard" }
+    t.started_at { 1.hour.from_now }
+    t.finished_at { 1.week.from_now }
+    t.initial_bid_cents { 100 }
+    t.minimal_bid_cents { 100 }
+  end
+
+  f.trait :default_running_standard do |t|
+    t.kind { "standard" }
+    t.status { "running" }
+    t.started_at { 1.hour.ago }
+    t.finished_at { 1.day.from_now }
+    t.initial_bid_cents { 100 }
+    t.minimal_bid_cents { 100 }
+  end
+
+  f.trait :default_finished_standard do |t|
+    t.kind { "standard" }
+    t.status { "finished" }
+    t.started_at { 2.days.ago }
+    t.finished_at { 1.day.ago }
+    t.initial_bid_cents { 100 }
+    t.minimal_bid_cents { 100 }
+  end
+
+  f.trait :default_paused_standard do |t|
+    t.kind { "standard" }
+    t.status { "paused" }
+    t.started_at { 1.hour.ago }
+    t.finished_at { 1.day.from_now }
+    t.initial_bid_cents { 100 }
+    t.minimal_bid_cents { 100 }
+  end
+
+  f.trait :default_penny do |t|
+    t.kind { "penny" }
+
+    t.stopwatch { 15 }
+    t.started_at { 1.hour.from_now }
+  end
+
+  f.trait :default_running_penny do |t|
+    t.kind { "penny" }
+    t.status { "running" }
+    t.started_at { 1.hour.ago }
+    t.finished_at { 60.seconds.from_now }
+    t.initial_bid_cents { 100 }
+  end
+
+  f.trait :default_closed do |t|
+    t.kind { "closed" }
+
+    t.initial_bid_cents { 100 }
+    t.started_at { 1.hour.from_now }
+    t.finished_at { 1.week.from_now }
+  end
+
+  f.trait :default_running_closed do |t|
+    t.kind { "closed" }
+    t.status { "running" }
+    t.started_at { 1.hour.ago }
+    t.finished_at { 1.day.from_now }
+    t.initial_bid_cents { 100 }
+  end
+end

--- a/spec/support/shared_examples/validate_stopwatch_contract.rb
+++ b/spec/support/shared_examples/validate_stopwatch_contract.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+shared_examples "validate_stopwatch_contract" do
+  context "when kind is penny and stopwatch is blank" do
+    let(:attributes) { {auction_id: auction.id, kind: auction.kind} }
+
+    it "expect failure with error message" do
+      expect(contract).to be_failure
+      expect(contract.errors[:stopwatch]).to include(I18n.t("contracts.errors.filled?"))
+    end
+  end
+
+  context "when kind is penny and stopwatch is not within the allowed range" do
+    let(:attributes) { {auction_id: auction.id, kind: auction.kind, stopwatch: 100} }
+
+    it "expect failure with error message" do
+      expect(contract).to be_failure
+      expect(contract.errors[:stopwatch]).to include(
+        I18n.t("contracts.errors.included_in?.arg.range", list_left: 15, list_right: 60)
+      )
+    end
+  end
+end


### PR DESCRIPTION
Issue number: resolves #4 

## Summary :red_circle:

This PR includes all the minimum resources necessary to create an auction, whether at the database level or at the business rule level. The version `0.7.0` Changelog contains all the details.

## Proposed / Possible solution :red_circle:

We create a specific context for the auction, and we follow all already established standards and conventions. As the auction has actions that are very specific, and can be complex, we created an additional internal module to deal with these complexities, respecting the SRP.

## How to test :policeman:

Start the related services, and open the console with the command `bin/console`. After that

```ruby
attributes = {}

AuctionFunCore::Operations::AuctionContext::CreateOperation.call(attributes) do |result|
  result.success { |auction| puts auction.to_h }
  result.failure { |failure| puts failure.errors.to_h }
end
```

> To simulate successful creation, change the hash of the attributes variable so that it meets all contract requirements.

## Risks / Impacts :red_circle:

- None anticipated

## Requirements for deployment :red_circle:

- Execute the migrate command before starting the deployment process.

