### PR TITLE
[AF-27] Create constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## [Unreleased]
 
+## [0.8.1] - 2024-03-06
+
+### Added
+
+- Added configuration constants module to store fixed values referring to business rules.
+
 ## [0.8.0] - 2024-03-06
 
 ### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    auction_fun_core (0.8.0)
+    auction_fun_core (0.8.1)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/auction_fun_core/business/configuration.rb
+++ b/lib/auction_fun_core/business/configuration.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module AuctionFunCore
+  module Business
+    module Configuration
+      AUCTION_KINDS = Relations::Auctions::KINDS.values
+      AUCTION_STATUSES = Relations::Auctions::STATUSES.values
+      AUCTION_MIN_TITLE_LENGTH = 6
+      AUCTION_MAX_TITLE_LENGTH = 255
+      AUCTION_STOPWATCH_MIN_VALUE = 15
+      AUCTION_STOPWATCH_MAX_VALUE = 60
+      MIN_NAME_LENGTH = 6
+      MAX_NAME_LENGTH = 128
+      MIN_PASSWORD_LENGTH = 6
+      MAX_PASSWORD_LENGTH = 128
+    end
+  end
+end

--- a/lib/auction_fun_core/contracts/application_contract.rb
+++ b/lib/auction_fun_core/contracts/application_contract.rb
@@ -7,12 +7,10 @@ module AuctionFunCore
     # Abstract base class for contracts.
     # @abstract
     class ApplicationContract < Dry::Validation::Contract
+      include AuctionFunCore::Business::Configuration
+
       I18N_MACRO_SCOPE = "contracts.errors.custom.macro"
       EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d-]+(\.[a-z\d-]+)*\.[a-z]+\z/i
-      MIN_NAME_LENGTH = 6
-      MAX_NAME_LENGTH = 128
-      MIN_PASSWORD_LENGTH = 6
-      MAX_PASSWORD_LENGTH = 128
 
       config.messages.backend = :i18n
       config.messages.default_locale = I18n.default_locale

--- a/lib/auction_fun_core/contracts/auction_context/create_contract.rb
+++ b/lib/auction_fun_core/contracts/auction_context/create_contract.rb
@@ -5,20 +5,17 @@ module AuctionFunCore
     module AuctionContext
       # Contract class to create new auctions.
       class CreateContract < Contracts::ApplicationContract
-        KINDS = Relations::Auctions::KINDS.values
-        REQUIRED_FINISHED_AT = KINDS - ["penny"]
-        MIN_TITLE_LENGTH = 6
-        MAX_TITLE_LENGTH = 255
-        STOPWATCH_MIN_VALUE = 15
-        STOPWATCH_MAX_VALUE = 60
+        include AuctionFunCore::Business::Configuration
+
+        REQUIRED_FINISHED_AT = AUCTION_KINDS - ["penny"]
 
         option :staff_repo, default: proc { Repos::StaffContext::StaffRepository.new }
 
         # @param [Hash] opts Sets an allowed list of parameters, as well as some initial validations.
         params do
           required(:staff_id).filled(:integer)
-          required(:title).filled(:string, size?: (MIN_TITLE_LENGTH..MAX_TITLE_LENGTH))
-          required(:kind).value(included_in?: KINDS)
+          required(:title).filled(:string, size?: (AUCTION_MIN_TITLE_LENGTH..AUCTION_MAX_TITLE_LENGTH))
+          required(:kind).value(included_in?: AUCTION_KINDS)
           required(:started_at).filled(:time)
           optional(:description)
           optional(:finished_at).filled(:time)
@@ -89,11 +86,11 @@ module AuctionFunCore
           key.failure(I18n.t("contracts.errors.filled?")) if !key? && values[:kind] == "penny"
 
           # Must be an integer between 15 and 60.
-          if key? && values[:kind] == "penny" && !value.between?(STOPWATCH_MIN_VALUE, STOPWATCH_MAX_VALUE)
+          if key? && values[:kind] == "penny" && !value.between?(AUCTION_STOPWATCH_MIN_VALUE, AUCTION_STOPWATCH_MAX_VALUE)
             key.failure(
               I18n.t(
                 "contracts.errors.included_in?.arg.range",
-                list_left: STOPWATCH_MIN_VALUE, list_right: STOPWATCH_MAX_VALUE
+                list_left: AUCTION_STOPWATCH_MIN_VALUE, list_right: AUCTION_STOPWATCH_MAX_VALUE
               )
             )
           end

--- a/lib/auction_fun_core/contracts/auction_context/processor/start_contract.rb
+++ b/lib/auction_fun_core/contracts/auction_context/processor/start_contract.rb
@@ -8,14 +8,13 @@ module AuctionFunCore
         # Contract class for start auctions.
         #
         class StartContract < Contracts::ApplicationContract
-          STOPWATCH_MIN_VALUE = 15
-          STOPWATCH_MAX_VALUE = 60
-          KINDS = Relations::Auctions::KINDS.values
+          include AuctionFunCore::Business::Configuration
+
           option :auction_repo, default: proc { Repos::AuctionContext::AuctionRepository.new }
 
           params do
             required(:auction_id).filled(:integer)
-            required(:kind).value(included_in?: KINDS)
+            required(:kind).value(included_in?: AUCTION_KINDS)
             optional(:stopwatch).filled(:integer)
           end
 
@@ -33,10 +32,10 @@ module AuctionFunCore
             key.failure(I18n.t("contracts.errors.filled?")) if !key? && values[:kind] == "penny"
 
             # Must be an integer between 15 and 60.
-            if key? && values[:kind] == "penny" && !value.between?(STOPWATCH_MIN_VALUE, STOPWATCH_MAX_VALUE)
+            if key? && values[:kind] == "penny" && !value.between?(AUCTION_STOPWATCH_MIN_VALUE, AUCTION_STOPWATCH_MAX_VALUE)
               key.failure(
                 I18n.t("contracts.errors.included_in?.arg.range",
-                  list_left: STOPWATCH_MIN_VALUE, list_right: STOPWATCH_MAX_VALUE)
+                  list_left: AUCTION_STOPWATCH_MIN_VALUE, list_right: AUCTION_STOPWATCH_MAX_VALUE)
               )
             end
           end

--- a/lib/auction_fun_core/version.rb
+++ b/lib/auction_fun_core/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module AuctionFunCore
-  VERSION = "0.8.0"
+  VERSION = "0.8.1"
 
   # Required class module is a gem dependency
   class Version; end

--- a/spec/auction_fun_core/contracts/auction_context/create_contract_spec.rb
+++ b/spec/auction_fun_core/contracts/auction_context/create_contract_spec.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
 RSpec.describe AuctionFunCore::Contracts::AuctionContext::CreateContract, type: :contract do
-  let(:min) { described_class::MIN_TITLE_LENGTH }
-  let(:max) { described_class::MAX_TITLE_LENGTH }
-  let(:stopwatch_min_value) { described_class::STOPWATCH_MIN_VALUE }
-  let(:stopwatch_max_value) { described_class::STOPWATCH_MAX_VALUE }
-  let(:kinds) { described_class::KINDS.join(", ") }
+  let(:min) { described_class::AUCTION_MIN_TITLE_LENGTH }
+  let(:max) { described_class::AUCTION_MAX_TITLE_LENGTH }
+  let(:stopwatch_min_value) { described_class::AUCTION_STOPWATCH_MIN_VALUE }
+  let(:stopwatch_max_value) { described_class::AUCTION_STOPWATCH_MAX_VALUE }
+  let(:kinds) { described_class::AUCTION_KINDS.join(", ") }
 
   describe "#call" do
     subject(:contract) { described_class.new.call(attributes) }
@@ -151,29 +151,8 @@ RSpec.describe AuctionFunCore::Contracts::AuctionContext::CreateContract, type: 
       end
     end
 
-    describe "stopwatch" do
-      context "when kind is penny and stopwatch is blank" do
-        let(:attributes) { {kind: "penny", initial_bid_cents: 1000} }
-
-        it "expect failure with error message" do
-          expect(contract).to be_failure
-          expect(contract.errors[:stopwatch]).to include(I18n.t("contracts.errors.filled?"))
-        end
-      end
-
-      context "when kind is penny and stopwatch is not within the allowed range" do
-        let(:attributes) { {kind: "penny", initial_bid_cents: 1000, stopwatch: 100} }
-
-        it "expect failure with error message" do
-          expect(contract).to be_failure
-          expect(contract.errors[:stopwatch]).to include(
-            I18n.t(
-              "contracts.errors.included_in?.arg.range",
-              list_left: stopwatch_min_value, list_right: stopwatch_max_value
-            )
-          )
-        end
-      end
+    it_behaves_like "validate_stopwatch_contract" do
+      let(:auction) { Factory.structs[:auction, kind: :penny, initial_bid_cents: 1000] }
     end
   end
 end

--- a/spec/auction_fun_core/contracts/auction_context/processor/start_contract_spec.rb
+++ b/spec/auction_fun_core/contracts/auction_context/processor/start_contract_spec.rb
@@ -42,7 +42,13 @@ RSpec.describe AuctionFunCore::Contracts::AuctionContext::Processor::StartContra
     end
 
     context "when attributes are valid" do
-      let(:attributes) { {auction_id: auction.id, kind: auction.kind, stopwatch: 15} }
+      let(:attributes) do
+        {
+          auction_id: auction.id,
+          kind: auction.kind,
+          stopwatch: described_class::AUCTION_STOPWATCH_MIN_VALUE
+        }
+      end
 
       it "expect return success" do
         expect(contract).to be_success

--- a/spec/auction_fun_core/contracts/auction_context/processor/start_contract_spec.rb
+++ b/spec/auction_fun_core/contracts/auction_context/processor/start_contract_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe AuctionFunCore::Contracts::AuctionContext::Processor::StartContract, type: :contract do
   let(:auction) { Factory[:auction, :default_standard] }
-  let(:kinds) { described_class::KINDS.join(", ") }
+  let(:kinds) { described_class::AUCTION_KINDS.join(", ") }
 
   describe "#call" do
     subject(:contract) { described_class.new.call(attributes) }

--- a/spec/auction_fun_core/contracts/bid_context/create_bid_closed_contract_spec.rb
+++ b/spec/auction_fun_core/contracts/bid_context/create_bid_closed_contract_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe AuctionFunCore::Contracts::BidContext::CreateBidClosedContract, t
     subject(:contract) { described_class.new.call(attributes) }
 
     context "when params are blank" do
-      let(:attributes) { {} }
+      let(:attributes) { Dry::Core::Constants::EMPTY_HASH }
 
       it "expect failure with error messages" do
         expect(contract).to be_failure

--- a/spec/auction_fun_core/contracts/bid_context/create_bid_penny_contract_spec.rb
+++ b/spec/auction_fun_core/contracts/bid_context/create_bid_penny_contract_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe AuctionFunCore::Contracts::BidContext::CreateBidPennyContract, ty
     subject(:contract) { described_class.new.call(attributes) }
 
     context "when params are blank" do
-      let(:attributes) { {} }
+      let(:attributes) { Dry::Core::Constants::EMPTY_HASH }
 
       it "expect failure with error messages" do
         expect(contract).to be_failure

--- a/spec/auction_fun_core/contracts/bid_context/create_bid_standard_contract_spec.rb
+++ b/spec/auction_fun_core/contracts/bid_context/create_bid_standard_contract_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe AuctionFunCore::Contracts::BidContext::CreateBidStandardContract,
     subject(:contract) { described_class.new.call(attributes) }
 
     context "when params are blank" do
-      let(:attributes) { {} }
+      let(:attributes) { Dry::Core::Constants::EMPTY_HASH }
 
       it "expect failure with error messages" do
         expect(contract).to be_failure

--- a/spec/auction_fun_core/contracts/staff_context/authentication_contract_spec.rb
+++ b/spec/auction_fun_core/contracts/staff_context/authentication_contract_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe AuctionFunCore::Contracts::StaffContext::AuthenticationContract, 
     subject(:contract) { described_class.new.call(attributes) }
 
     context "when params are blank" do
-      let(:attributes) { {} }
+      let(:attributes) { Dry::Core::Constants::EMPTY_HASH }
 
       it "expect failure with error messages" do
         expect(contract).to be_failure

--- a/spec/auction_fun_core/contracts/user_context/authentication_contract_spec.rb
+++ b/spec/auction_fun_core/contracts/user_context/authentication_contract_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe AuctionFunCore::Contracts::UserContext::AuthenticationContract, t
     subject(:contract) { described_class.new.call(attributes) }
 
     context "when params are blank" do
-      let(:attributes) { {} }
+      let(:attributes) { Dry::Core::Constants::EMPTY_HASH }
 
       it "expect failure with error messages" do
         expect(contract).to be_failure

--- a/spec/auction_fun_core/contracts/user_context/email_confirmation_contract_spec.rb
+++ b/spec/auction_fun_core/contracts/user_context/email_confirmation_contract_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe AuctionFunCore::Contracts::UserContext::EmailConfirmationContract
     subject(:contract) { described_class.new.call(attributes) }
 
     context "when params are blank" do
-      let(:attributes) { {} }
+      let(:attributes) { Dry::Core::Constants::EMPTY_HASH }
 
       it "expect failure with error messages" do
         expect(contract).to be_failure

--- a/spec/auction_fun_core/contracts/user_context/phone_confirmation_contract_spec.rb
+++ b/spec/auction_fun_core/contracts/user_context/phone_confirmation_contract_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe AuctionFunCore::Contracts::UserContext::PhoneConfirmationContract
     subject(:contract) { described_class.new.call(attributes) }
 
     context "when params are blank" do
-      let(:attributes) { {} }
+      let(:attributes) { Dry::Core::Constants::EMPTY_HASH }
 
       it "expect failure with error messages" do
         expect(contract).to be_failure

--- a/spec/auction_fun_core/operations/bid_context/create_bid_closed_operation_spec.rb
+++ b/spec/auction_fun_core/operations/bid_context/create_bid_closed_operation_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe AuctionFunCore::Operations::BidContext::CreateBidClosedOperation,
     subject(:operation) { described_class.new.call(attributes) }
 
     context "when contract are not valid" do
-      let(:attributes) { {} }
+      let(:attributes) { Dry::Core::Constants::EMPTY_HASH }
 
       it "expect not persist new bid on database" do
         expect(bid_repository.count).to be_zero

--- a/spec/auction_fun_core/operations/bid_context/create_bid_standard_operation_spec.rb
+++ b/spec/auction_fun_core/operations/bid_context/create_bid_standard_operation_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe AuctionFunCore::Operations::BidContext::CreateBidStandardOperatio
     subject(:operation) { described_class.new.call(attributes) }
 
     context "when contract are not valid" do
-      let(:attributes) { {} }
+      let(:attributes) { Dry::Core::Constants::EMPTY_HASH }
 
       it "expect return failure with error messages" do
         expect(operation).to be_failure

--- a/spec/auction_fun_core_spec.rb
+++ b/spec/auction_fun_core_spec.rb
@@ -2,6 +2,6 @@
 
 RSpec.describe AuctionFunCore do
   it "has a version number" do
-    expect(AuctionFunCore::VERSION).to eq("0.8.0")
+    expect(AuctionFunCore::VERSION).to eq("0.8.1")
   end
 end

--- a/spec/support/factories/auctions.rb
+++ b/spec/support/factories/auctions.rb
@@ -95,7 +95,7 @@ Factory.define(:auction, struct_namespace: AuctionFunCore::Entities) do |f|
   f.trait :default_penny do |t|
     t.kind { "penny" }
 
-    t.stopwatch { 15 }
+    t.stopwatch { AuctionFunCore::Business::Configuration::AUCTION_STOPWATCH_MIN_VALUE }
     t.started_at { 1.hour.from_now }
   end
 

--- a/spec/support/shared_examples/validate_name_contract.rb
+++ b/spec/support/shared_examples/validate_name_contract.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 shared_examples "validate_name_contract" do |factory_name|
-  let(:min) { AuctionFunCore::Contracts::ApplicationContract::MIN_NAME_LENGTH }
-  let(:max) { AuctionFunCore::Contracts::ApplicationContract::MAX_NAME_LENGTH }
+  let(:min) { AuctionFunCore::Business::Configuration::MIN_NAME_LENGTH }
+  let(:max) { AuctionFunCore::Business::Configuration::MAX_NAME_LENGTH }
   let(:factory) { Factory[factory_name] }
 
   context "when the characters in the name are outside the allowed range" do

--- a/spec/support/shared_examples/validate_password_contract.rb
+++ b/spec/support/shared_examples/validate_password_contract.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 shared_examples "validate_password_contract" do |factory_name|
-  let(:min) { AuctionFunCore::Contracts::ApplicationContract::MIN_PASSWORD_LENGTH }
-  let(:max) { AuctionFunCore::Contracts::ApplicationContract::MAX_PASSWORD_LENGTH }
+  let(:min) { AuctionFunCore::Business::Configuration::MIN_PASSWORD_LENGTH }
+  let(:max) { AuctionFunCore::Business::Configuration::MAX_PASSWORD_LENGTH }
   let(:factory) { Factory[factory_name] }
 
   context "when password characters are outside the allowed range" do

--- a/spec/support/shared_examples/validate_stopwatch_contract.rb
+++ b/spec/support/shared_examples/validate_stopwatch_contract.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 shared_examples "validate_stopwatch_contract" do
+  let(:min) { AuctionFunCore::Business::Configuration::AUCTION_STOPWATCH_MIN_VALUE }
+  let(:max) { AuctionFunCore::Business::Configuration::AUCTION_STOPWATCH_MAX_VALUE }
+
   context "when kind is penny and stopwatch is blank" do
     let(:attributes) { {auction_id: auction.id, kind: auction.kind} }
 
@@ -11,12 +14,18 @@ shared_examples "validate_stopwatch_contract" do
   end
 
   context "when kind is penny and stopwatch is not within the allowed range" do
-    let(:attributes) { {auction_id: auction.id, kind: auction.kind, stopwatch: 100} }
+    let(:attributes) do
+      {
+        auction_id: auction.id,
+        kind: auction.kind,
+        stopwatch: max + 1
+      }
+    end
 
     it "expect failure with error message" do
       expect(contract).to be_failure
       expect(contract.errors[:stopwatch]).to include(
-        I18n.t("contracts.errors.included_in?.arg.range", list_left: 15, list_right: 60)
+        I18n.t("contracts.errors.included_in?.arg.range", list_left: min, list_right: max)
       )
     end
   end


### PR DESCRIPTION
Issue number: resolves #27 

## Summary :red_circle:

This PR includes a refactoring regarding the addition of constants to parameterize constant values of business rules. The idea is aimed at ease of maintenance and future changes. The version `0.8.1` Changelog contains all the details.

## Proposed / Possible solution :red_circle:

We added a settings module to store rule values as constants in the code.

## How to test :policeman:

> Nothing has been added or changed, so everything should be working the same as the previous version (0.8.0).

## Risks / Impacts :red_circle:

- None anticipated

## Requirements for deployment :red_circle:

- None anticipated