### PR TITLE
[AF-29] Create actions for pause and unpause auctions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## [Unreleased]
 
+## [0.8.3] - 2024-03-12
+
+### Added
+
+- Processing actions to pause and unpause an auction.
+
 ## [0.8.1] - 2024-03-06
 
 ### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    auction_fun_core (0.8.1)
+    auction_fun_core (0.8.3)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/auction_fun_core/contracts/auction_context/processor/pause_contract.rb
+++ b/lib/auction_fun_core/contracts/auction_context/processor/pause_contract.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module AuctionFunCore
+  module Contracts
+    module AuctionContext
+      module Processor
+        ##
+        # Contract class for pause auction.
+        #
+        class PauseContract < Contracts::ApplicationContract
+          option :auction_repository, default: proc { Repos::AuctionContext::AuctionRepository.new }
+
+          params do
+            required(:auction_id).filled(:integer)
+          end
+
+          # Validation for auction.
+          # Validates if the auction exists in the database and check if  only auctions
+          # with a "running" status can be paused.
+          rule(:auction_id) do |context:|
+            context[:auction] ||= auction_repository.by_id(value)
+            key.failure(I18n.t("contracts.errors.custom.not_found")) unless context[:auction]
+
+            unless %w[running].include?(context[:auction].status)
+              key.failure(
+                I18n.t("contracts.errors.custom.bids.invalid_status", status: context[:auction].status)
+              )
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/auction_fun_core/contracts/auction_context/processor/unpause_contract.rb
+++ b/lib/auction_fun_core/contracts/auction_context/processor/unpause_contract.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module AuctionFunCore
+  module Contracts
+    module AuctionContext
+      module Processor
+        ##
+        # Contract class for unpause auction.
+        #
+        class UnpauseContract < Contracts::ApplicationContract
+          option :auction_repository, default: proc { Repos::AuctionContext::AuctionRepository.new }
+
+          params do
+            required(:auction_id).filled(:integer)
+          end
+
+          # Validation for auction.
+          # Validates if the auction exists in the database and and checks if the
+          # auction has a paused status.
+          rule(:auction_id) do |context:|
+            context[:auction] ||= auction_repository.by_id(value)
+            key.failure(I18n.t("contracts.errors.custom.not_found")) unless context[:auction]
+
+            unless %w[paused].include?(context[:auction].status)
+              key.failure(
+                I18n.t("contracts.errors.custom.bids.invalid_status", status: context[:auction].status)
+              )
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/auction_fun_core/events/app.rb
+++ b/lib/auction_fun_core/events/app.rb
@@ -11,6 +11,8 @@ module AuctionFunCore
       register_event("auctions.created")
       register_event("auctions.started")
       register_event("auctions.finished")
+      register_event("auctions.paused")
+      register_event("auctions.unpaused")
 
       register_event("bids.created")
 

--- a/lib/auction_fun_core/events/listener.rb
+++ b/lib/auction_fun_core/events/listener.rb
@@ -23,6 +23,18 @@ module AuctionFunCore
         logger("Finished auction: #{auction.to_h}")
       end
 
+      # Listener for to *auctions.paused* event.
+      # @param event [ROM::Struct::Auction] the auction object
+      def on_auctions_paused(auction)
+        logger("Paused auction with: #{auction.to_h}")
+      end
+
+      # Listener for to *auctions.unpaused* event.
+      # @param event [ROM::Struct::Auction] the auction object
+      def on_auctions_unpaused(auction)
+        logger("Unpaused auction with: #{auction.to_h}")
+      end
+
       # Listener for to *bids.created* event.
       # @param event [Integer] Auction ID
       def on_bids_created(bid)

--- a/lib/auction_fun_core/operations/auction_context/processor/pause_operation.rb
+++ b/lib/auction_fun_core/operations/auction_context/processor/pause_operation.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module AuctionFunCore
+  module Operations
+    module AuctionContext
+      module Processor
+        ##
+        # Operation class for dispatch pause auction.
+        # By default, this change auction status from 'running' to 'paused'.
+        #
+        class PauseOperation < AuctionFunCore::Operations::Base
+          include Import["repos.auction_context.auction_repository"]
+          include Import["contracts.auction_context.processor.pause_contract"]
+
+          # @todo Add custom doc
+          def self.call(attributes, &block)
+            operation = new.call(attributes)
+
+            return operation unless block
+
+            Dry::Matcher::ResultMatcher.call(operation, &block)
+          end
+
+          def call(attributes)
+            attrs = yield validate(attributes)
+
+            auction_repository.transaction do |_t|
+              @auction, _ = auction_repository.update(attrs[:auction_id], status: "paused")
+
+              publish_auction_pause_event(@auction)
+            end
+
+            Success(attrs[:auction_id])
+          end
+
+          private
+
+          # Calls the finish contract class to perform the validation
+          # of the informed attributes.
+          # @param attrs [Hash] auction attributes
+          # @return [Dry::Monads::Result::Success, Dry::Monads::Result::Failure]
+          def validate(attributes)
+            contract = pause_contract.call(attributes)
+
+            return Failure(contract.errors.to_h) if contract.failure?
+
+            Success(contract.to_h)
+          end
+
+          def publish_auction_pause_event(auction)
+            Application[:event].publish("auctions.paused", auction.to_h)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/auction_fun_core/operations/auction_context/processor/unpause_operation.rb
+++ b/lib/auction_fun_core/operations/auction_context/processor/unpause_operation.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module AuctionFunCore
+  module Operations
+    module AuctionContext
+      module Processor
+        ##
+        # Operation class for dispatch unpause auction.
+        # By default, this change auction status from 'paused' to 'running'.
+        #
+        class UnpauseOperation < AuctionFunCore::Operations::Base
+          include Import["repos.auction_context.auction_repository"]
+          include Import["contracts.auction_context.processor.unpause_contract"]
+
+          # @todo Add custom doc
+          def self.call(attributes, &block)
+            operation = new.call(attributes)
+
+            return operation unless block
+
+            Dry::Matcher::ResultMatcher.call(operation, &block)
+          end
+
+          def call(attributes)
+            attrs = yield validate(attributes)
+
+            auction_repository.transaction do |_t|
+              @auction, _ = auction_repository.update(attrs[:auction_id], status: "running")
+
+              publish_auction_unpause_event(@auction)
+            end
+
+            Success(attrs[:auction_id])
+          end
+
+          private
+
+          # Calls the unpause contract class to perform the validation
+          # of the informed attributes.
+          # @param attrs [Hash] auction attributes
+          # @return [Dry::Monads::Result::Success, Dry::Monads::Result::Failure]
+          def validate(attributes)
+            contract = unpause_contract.call(attributes)
+
+            return Failure(contract.errors.to_h) if contract.failure?
+
+            Success(contract.to_h)
+          end
+
+          def publish_auction_unpause_event(auction)
+            Application[:event].publish("auctions.unpaused", auction.to_h)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/auction_fun_core/version.rb
+++ b/lib/auction_fun_core/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module AuctionFunCore
-  VERSION = "0.8.1"
+  VERSION = "0.8.3"
 
   # Required class module is a gem dependency
   class Version; end

--- a/spec/auction_fun_core/contracts/auction_context/processor/pause_contract_spec.rb
+++ b/spec/auction_fun_core/contracts/auction_context/processor/pause_contract_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+RSpec.describe AuctionFunCore::Contracts::AuctionContext::Processor::PauseContract, type: :contract do
+  let(:auction) { Factory[:auction, :default_standard] }
+
+  describe "#call" do
+    subject(:contract) { described_class.new.call(attributes) }
+
+    context "when attributes are invalid" do
+      let(:attributes) { Dry::Core::Constants::EMPTY_HASH }
+
+      it "expect failure with error messages" do
+        expect(contract).to be_failure
+        expect(contract.errors[:auction_id]).to include(I18n.t("contracts.errors.key?"))
+      end
+    end
+
+    context "when auction status is different to 'running'" do
+      let(:attributes) { {auction_id: auction.id} }
+
+      it "expect failure with error messages" do
+        expect(contract).to be_failure
+        expect(contract.errors[:auction_id]).to include(
+          I18n.t("contracts.errors.custom.bids.invalid_status")
+        )
+      end
+    end
+
+    context "when auction status is equal to 'running'" do
+      let(:auction) { Factory[:auction, :default_running_standard] }
+      let(:attributes) { {auction_id: auction.id} }
+
+      it "expect return success" do
+        expect(contract).to be_success
+        expect(contract.context[:auction]).to be_a(AuctionFunCore::Entities::Auction)
+      end
+    end
+  end
+end

--- a/spec/auction_fun_core/contracts/auction_context/processor/unpause_contract_spec.rb
+++ b/spec/auction_fun_core/contracts/auction_context/processor/unpause_contract_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+RSpec.describe AuctionFunCore::Contracts::AuctionContext::Processor::UnpauseContract, type: :contract do
+  let(:auction) { Factory[:auction, :default_standard] }
+
+  describe "#call" do
+    subject(:contract) { described_class.new.call(attributes) }
+
+    context "when attributes are invalid" do
+      let(:attributes) { Dry::Core::Constants::EMPTY_HASH }
+
+      it "expect failure with error messages" do
+        expect(contract).to be_failure
+        expect(contract.errors[:auction_id]).to include(I18n.t("contracts.errors.key?"))
+      end
+    end
+
+    context "when auction status is different to 'paused'" do
+      let(:attributes) { {auction_id: auction.id} }
+
+      it "expect failure with error messages" do
+        expect(contract).to be_failure
+        expect(contract.errors[:auction_id]).to include(
+          I18n.t("contracts.errors.custom.bids.invalid_status")
+        )
+      end
+    end
+
+    context "when auction status is equal to 'paused'" do
+      let(:auction) { Factory[:auction, :default_paused_standard] }
+      let(:attributes) { {auction_id: auction.id} }
+
+      it "expect return success" do
+        expect(contract).to be_success
+        expect(contract.context[:auction]).to be_a(AuctionFunCore::Entities::Auction)
+      end
+    end
+  end
+end

--- a/spec/auction_fun_core/operations/auction_context/processor/pause_operation_spec.rb
+++ b/spec/auction_fun_core/operations/auction_context/processor/pause_operation_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe AuctionFunCore::Operations::AuctionContext::Processor::PauseOperation, type: :operation do
+  let(:auction_repository) { AuctionFunCore::Repos::AuctionContext::AuctionRepository.new }
+  let(:auction) { Factory[:auction, :default_running_standard] }
+
+  describe ".call(attributes, &block)" do
+    let(:operation) { described_class }
+
+    context "when block is given" do
+      context "when operation happens with success" do
+        let(:attributes) { {auction_id: auction.id} }
+
+        it "expect result success matching block" do
+          matched_success = nil
+          matched_failure = nil
+
+          operation.call(attributes) do |o|
+            o.success { |v| matched_success = v }
+            o.failure { |f| matched_failure = f }
+          end
+
+          expect(matched_success).to eq(auction.id)
+          expect(matched_failure).to be_nil
+        end
+      end
+
+      context "when operation happens with failure" do
+        let(:attributes) { Dry::Core::Constants::EMPTY_HASH }
+
+        it "expect result matching block" do
+          matched_success = nil
+          matched_failure = nil
+
+          operation.call(attributes) do |o|
+            o.success { |v| matched_success = v }
+            o.failure { |f| matched_failure = f }
+          end
+
+          expect(matched_success).to be_nil
+          expect(matched_failure[:auction_id]).to include(I18n.t("contracts.errors.key?"))
+        end
+      end
+    end
+  end
+
+  describe "#call(attributes)" do
+    subject(:operation) { described_class.new.call(attributes) }
+
+    context "when contract is invalid" do
+      let(:attributes) { Dry::Core::Constants::EMPTY_HASH }
+
+      it "expect not change auction status" do
+        expect { operation }.not_to change { auction_repository.by_id(auction.id).status }
+      end
+
+      it "expect return failure with error messages" do
+        expect(operation.failure[:auction_id]).to include(I18n.t("contracts.errors.key?"))
+      end
+    end
+
+    context "when contract is valid" do
+      let(:attributes) { {auction_id: auction.id} }
+
+      it "expect update status auction record on database" do
+        expect { operation }.to change { auction_repository.by_id(auction.id).status }.from("running").to("paused")
+      end
+
+      it "expect publish the auction pause event" do
+        allow(AuctionFunCore::Application[:event]).to receive(:publish)
+
+        operation
+
+        expect(AuctionFunCore::Application[:event]).to have_received(:publish).once
+      end
+    end
+  end
+end

--- a/spec/auction_fun_core/operations/auction_context/processor/unpause_operation_spec.rb
+++ b/spec/auction_fun_core/operations/auction_context/processor/unpause_operation_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe AuctionFunCore::Operations::AuctionContext::Processor::UnpauseOperation, type: :operation do
+  let(:auction_repository) { AuctionFunCore::Repos::AuctionContext::AuctionRepository.new }
+  let(:auction) { Factory[:auction, :default_paused_standard] }
+
+  describe ".call(attributes, &block)" do
+    let(:operation) { described_class }
+
+    context "when block is given" do
+      context "when operation happens with success" do
+        let(:attributes) { {auction_id: auction.id} }
+
+        it "expect result success matching block" do
+          matched_success = nil
+          matched_failure = nil
+
+          operation.call(attributes) do |o|
+            o.success { |v| matched_success = v }
+            o.failure { |f| matched_failure = f }
+          end
+
+          expect(matched_success).to eq(auction.id)
+          expect(matched_failure).to be_nil
+        end
+      end
+
+      context "when operation happens with failure" do
+        let(:attributes) { Dry::Core::Constants::EMPTY_HASH }
+
+        it "expect result matching block" do
+          matched_success = nil
+          matched_failure = nil
+
+          operation.call(attributes) do |o|
+            o.success { |v| matched_success = v }
+            o.failure { |f| matched_failure = f }
+          end
+
+          expect(matched_success).to be_nil
+          expect(matched_failure[:auction_id]).to include(I18n.t("contracts.errors.key?"))
+        end
+      end
+    end
+  end
+
+  describe "#call(attributes)" do
+    subject(:operation) { described_class.new.call(attributes) }
+
+    context "when contract is invalid" do
+      let(:attributes) { Dry::Core::Constants::EMPTY_HASH }
+
+      it "expect not change auction status" do
+        expect { operation }.not_to change { auction_repository.by_id(auction.id).status }
+      end
+
+      it "expect return failure with error messages" do
+        expect(operation.failure[:auction_id]).to include(I18n.t("contracts.errors.key?"))
+      end
+    end
+
+    context "when contract is valid" do
+      let(:attributes) { {auction_id: auction.id} }
+
+      it "expect update status auction record on database" do
+        expect { operation }.to change { auction_repository.by_id(auction.id).status }.from("paused").to("running")
+      end
+
+      it "expect publish the auction unpause event" do
+        allow(AuctionFunCore::Application[:event]).to receive(:publish)
+
+        operation
+
+        expect(AuctionFunCore::Application[:event]).to have_received(:publish).once
+      end
+    end
+  end
+end

--- a/spec/auction_fun_core_spec.rb
+++ b/spec/auction_fun_core_spec.rb
@@ -2,6 +2,6 @@
 
 RSpec.describe AuctionFunCore do
   it "has a version number" do
-    expect(AuctionFunCore::VERSION).to eq("0.8.1")
+    expect(AuctionFunCore::VERSION).to eq("0.8.3")
   end
 end

--- a/spec/support/factories/auctions.rb
+++ b/spec/support/factories/auctions.rb
@@ -59,6 +59,7 @@ Factory.define(:auction, struct_namespace: AuctionFunCore::Entities) do |f|
 
   f.trait :default_standard do |t|
     t.kind { "standard" }
+
     t.started_at { 1.hour.from_now }
     t.finished_at { 1.week.from_now }
     t.initial_bid_cents { 100 }
@@ -68,6 +69,7 @@ Factory.define(:auction, struct_namespace: AuctionFunCore::Entities) do |f|
   f.trait :default_running_standard do |t|
     t.kind { "standard" }
     t.status { "running" }
+
     t.started_at { 1.hour.ago }
     t.finished_at { 1.day.from_now }
     t.initial_bid_cents { 100 }
@@ -77,6 +79,7 @@ Factory.define(:auction, struct_namespace: AuctionFunCore::Entities) do |f|
   f.trait :default_finished_standard do |t|
     t.kind { "standard" }
     t.status { "finished" }
+
     t.started_at { 2.days.ago }
     t.finished_at { 1.day.ago }
     t.initial_bid_cents { 100 }
@@ -86,6 +89,7 @@ Factory.define(:auction, struct_namespace: AuctionFunCore::Entities) do |f|
   f.trait :default_paused_standard do |t|
     t.kind { "standard" }
     t.status { "paused" }
+
     t.started_at { 1.hour.ago }
     t.finished_at { 1.day.from_now }
     t.initial_bid_cents { 100 }
@@ -102,6 +106,7 @@ Factory.define(:auction, struct_namespace: AuctionFunCore::Entities) do |f|
   f.trait :default_running_penny do |t|
     t.kind { "penny" }
     t.status { "running" }
+
     t.started_at { 1.hour.ago }
     t.finished_at { 60.seconds.from_now }
     t.initial_bid_cents { 100 }
@@ -118,6 +123,7 @@ Factory.define(:auction, struct_namespace: AuctionFunCore::Entities) do |f|
   f.trait :default_running_closed do |t|
     t.kind { "closed" }
     t.status { "running" }
+
     t.started_at { 1.hour.ago }
     t.finished_at { 1.day.from_now }
     t.initial_bid_cents { 100 }


### PR DESCRIPTION
Issue number: resolves #29 

## Summary :red_circle:

This PR includes all the minimum resources necessary to pause and unpause an auction, whether at the database level or at the business rule level. The version `0.8.3` Changelog contains all the details.

## Proposed / Possible solution :red_circle:

We create a specific contexts for the resources, and we follow all already established standards and conventions.

## How to test :policeman:

Start the related services, and open the console with the command `bin/console`. After that

#### Pause auction
```ruby
attributes = {}

AuctionFunCore::Operations::AuctionContext::Processor::PauseOperation.call(attributes) do |result|
  result.success { |auction| puts auction.to_h }
  result.failure { |failure| puts failure.errors.to_h }
end
```

#### Unpause auction

```ruby
attributes = {}

AuctionFunCore::Operations::AuctionContext::Processor::UnpauseOperation.call(attributes) do |result|
  result.success { |auction| puts auction.to_h }
  result.failure { |failure| puts failure.errors.to_h }
end
```

> To simulate successful creation, change the hash of the attributes variable so that it meets all contract requirements.

## Risks / Impacts :red_circle:

- None anticipated

## Requirements for deployment :red_circle:

- None anticipated