### PR TITLE
[AF-36] Add lib to rubygems

### DIFF
--- a/auction_fun_core.gemspec
+++ b/auction_fun_core.gemspec
@@ -10,11 +10,11 @@ Gem::Specification.new do |spec|
 
   spec.summary = "It's a lib that contains all auctionfun's business rules!"
   spec.description = "Practical application of clean architecture in a real business idea using ruby."
-  spec.homepage = "https://github.com/ricardopacheco/auction-fun-core"
+  spec.homepage = "https://rubygems.org/gems/auction_fun_core"
   spec.license = "MIT"
   spec.required_ruby_version = ">= 3.3.0"
 
-  spec.metadata["allowed_push_host"] = "TODO: Set to your gem server 'https://example.com'"
+  spec.metadata["allowed_push_host"] = "https://rubygems.org"
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/ricardopacheco/auction-fun-core"


### PR DESCRIPTION
Issue number: resolves #36 

## Summary :red_circle:

As it is open-source code, the idea is to make the gem available in the main Ruby gem repository.

## Proposed / Possible solution :red_circle:

At the root of the project, there is a file with the extension .gemspec. You just need to configure it.

## How to test :policeman:

In any Ruby project using bundler, just add to the Gemfile: `gem 'auction_fun_core`.

## Risks / Impacts :red_circle:

- None anticipated

## Requirements for deployment :red_circle:

- None anticipated