### PR TITLE
[AF-40] Fix immutability ROM objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## [Unreleased]
 
+## [0.8.7] - 2024-04-23
+
+### Added
+
+- Removing default values from relations;
+- Rebuild factories to not contain default values;
+- Add automated tests for auction relations;
+
 ## [0.8.6] - 2024-04-23
 
 ### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    auction_fun_core (0.8.6)
+    auction_fun_core (0.8.7)
       activesupport (= 7.1.3.2)
       bcrypt (= 3.1.20)
       dotenv (= 3.1.0)

--- a/lib/auction_fun_core/operations/auction_context/processor/finish/closed_operation.rb
+++ b/lib/auction_fun_core/operations/auction_context/processor/finish/closed_operation.rb
@@ -69,7 +69,7 @@ module AuctionFunCore
             end
 
             def update_finished_auction(auction, summary)
-              attrs = {kind: auction.kind, status: "finished"}
+              attrs = {status: "finished"}
               attrs[:winner_id] = summary.winner_id if summary.winner_id.present?
 
               Success(attrs)

--- a/lib/auction_fun_core/operations/auction_context/processor/finish/penny_operation.rb
+++ b/lib/auction_fun_core/operations/auction_context/processor/finish/penny_operation.rb
@@ -69,7 +69,7 @@ module AuctionFunCore
             end
 
             def update_finished_auction(auction, summary)
-              attrs = {kind: auction.kind, status: "finished"}
+              attrs = {status: "finished"}
               attrs[:winner_id] = summary.winner_id if summary.winner_id.present?
 
               Success(attrs)

--- a/lib/auction_fun_core/operations/auction_context/processor/finish/standard_operation.rb
+++ b/lib/auction_fun_core/operations/auction_context/processor/finish/standard_operation.rb
@@ -71,7 +71,7 @@ module AuctionFunCore
             end
 
             def update_finished_auction(auction, summary)
-              attrs = {kind: auction.kind, status: "finished"}
+              attrs = {status: "finished"}
               attrs[:winner_id] = summary.winner_id if summary.winner_id.present?
 
               Success(attrs)

--- a/lib/auction_fun_core/operations/staff_context/registration_operation.rb
+++ b/lib/auction_fun_core/operations/staff_context/registration_operation.rb
@@ -21,6 +21,7 @@ module AuctionFunCore
         # @todo Add custom doc
         def call(attributes)
           values = yield validate_contract(attributes)
+          values = yield assign_default_values(values)
           values_with_encrypt_password = yield encrypt_password(values)
 
           staff_repository.transaction do |_t|
@@ -42,6 +43,15 @@ module AuctionFunCore
           return Failure(contract.errors.to_h) if contract.failure?
 
           Success(contract.to_h)
+        end
+
+        # By default, there can only be a single root staff. All other members have their type set to 'common'.
+        # @param attrs [Hash] user attributes
+        # @return [Dry::Monads::Result::Success]
+        def assign_default_values(attrs)
+          attrs[:kind] = "common"
+
+          Success(attrs)
         end
 
         # Transforms the password attribute, encrypting it to be saved in the database.

--- a/lib/auction_fun_core/relations/auctions.rb
+++ b/lib/auction_fun_core/relations/auctions.rb
@@ -7,9 +7,8 @@ module AuctionFunCore
     class Auctions < ROM::Relation[:sql]
       use :pagination, per_page: 10
 
-      KINDS = Types::Coercible::String.default("standard").enum("standard", "penny", "closed")
-      STATUSES = Types::Coercible::String.default("scheduled")
-        .enum("scheduled", "running", "paused", "canceled", "finished")
+      KINDS = Types::Coercible::String.enum("standard", "penny", "closed")
+      STATUSES = Types::Coercible::String.enum("scheduled", "running", "paused", "canceled", "finished")
 
       schema(:auctions, infer: true) do
         attribute :id, Types::Integer

--- a/lib/auction_fun_core/relations/staffs.rb
+++ b/lib/auction_fun_core/relations/staffs.rb
@@ -7,7 +7,7 @@ module AuctionFunCore
     class Staffs < ROM::Relation[:sql]
       use :pagination, per_page: 10
 
-      STAFF_KINDS = Types::Coercible::String.default("common").enum("root", "common")
+      STAFF_KINDS = Types::Coercible::String.enum("root", "common")
 
       schema(:staffs, infer: true) do
         attribute :id, Types::Integer

--- a/lib/auction_fun_core/version.rb
+++ b/lib/auction_fun_core/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module AuctionFunCore
-  VERSION = "0.8.6"
+  VERSION = "0.8.7"
 
   # Required class module is a gem dependency
   class Version; end

--- a/spec/auction_fun_core/contracts/auction_context/create_contract_spec.rb
+++ b/spec/auction_fun_core/contracts/auction_context/create_contract_spec.rb
@@ -152,7 +152,7 @@ RSpec.describe AuctionFunCore::Contracts::AuctionContext::CreateContract, type: 
     end
 
     it_behaves_like "validate_stopwatch_contract" do
-      let(:auction) { Factory.structs[:auction, kind: :penny, initial_bid_cents: 1000] }
+      let(:auction) { Factory.structs[:auction, :with_kind_penny, :with_status_scheduled, initial_bid_cents: 1000] }
     end
   end
 end

--- a/spec/auction_fun_core/contracts/auction_context/post_auction/participant_contract_spec.rb
+++ b/spec/auction_fun_core/contracts/auction_context/post_auction/participant_contract_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe AuctionFunCore::Contracts::AuctionContext::PostAuction::ParticipantContract, type: :contract do
-  let(:auction) { Factory[:auction, :default_standard, :with_winner] }
+  let(:auction) { Factory[:auction, :default_finished_standard, :with_winner] }
   let(:participant) { Factory[:user] }
 
   describe "#call" do
@@ -64,7 +64,7 @@ RSpec.describe AuctionFunCore::Contracts::AuctionContext::PostAuction::Participa
       end
 
       before do
-        Factory[:bid, auction_id: auction.id, user_id: participant.id, value_cents: auction.minimal_bid_cents]
+        Factory[:bid, auction: auction, user_id: participant.id, value_cents: auction.minimal_bid_cents]
       end
 
       it "expect return sucess" do

--- a/spec/auction_fun_core/contracts/auction_context/post_auction/winner_contract_spec.rb
+++ b/spec/auction_fun_core/contracts/auction_context/post_auction/winner_contract_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe AuctionFunCore::Contracts::AuctionContext::PostAuction::WinnerContract, type: :contract do
-  let(:auction) { Factory[:auction, :default_standard, :with_winner] }
+  let(:auction) { Factory[:auction, :default_finished_standard, :with_winner] }
   let(:winner) { auction.winner }
 
   describe "#call" do
@@ -45,7 +45,7 @@ RSpec.describe AuctionFunCore::Contracts::AuctionContext::PostAuction::WinnerCon
     context "when the informed winner is different from the one set in the auction" do
       let(:real_winner) { Factory[:user] }
       let(:fake_winner) { Factory[:user] }
-      let(:auction) { Factory[:auction, :default_standard, winner_id: real_winner.id] }
+      let(:auction) { Factory[:auction, :default_scheduled_standard, winner_id: real_winner.id] }
       let(:attributes) do
         {
           auction_id: auction.id,

--- a/spec/auction_fun_core/contracts/auction_context/processor/pause_contract_spec.rb
+++ b/spec/auction_fun_core/contracts/auction_context/processor/pause_contract_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe AuctionFunCore::Contracts::AuctionContext::Processor::PauseContract, type: :contract do
-  let(:auction) { Factory[:auction, :default_standard] }
+  let(:auction) { Factory[:auction, :default_scheduled_standard] }
 
   describe "#call" do
     subject(:contract) { described_class.new.call(attributes) }

--- a/spec/auction_fun_core/contracts/auction_context/processor/start_contract_spec.rb
+++ b/spec/auction_fun_core/contracts/auction_context/processor/start_contract_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe AuctionFunCore::Contracts::AuctionContext::Processor::StartContract, type: :contract do
-  let(:auction) { Factory[:auction, :default_standard] }
+  let(:auction) { Factory[:auction, :default_scheduled_standard] }
   let(:kinds) { described_class::AUCTION_KINDS.join(", ") }
 
   describe "#call" do
@@ -18,7 +18,7 @@ RSpec.describe AuctionFunCore::Contracts::AuctionContext::Processor::StartContra
     end
 
     it_behaves_like "validate_stopwatch_contract" do
-      let(:auction) { Factory[:auction, :default_penny] }
+      let(:auction) { Factory[:auction, :default_scheduled_penny] }
     end
 
     context "when auction_id is not founded on database" do

--- a/spec/auction_fun_core/contracts/auction_context/processor/unpause_contract_spec.rb
+++ b/spec/auction_fun_core/contracts/auction_context/processor/unpause_contract_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe AuctionFunCore::Contracts::AuctionContext::Processor::UnpauseContract, type: :contract do
-  let(:auction) { Factory[:auction, :default_standard] }
+  let(:auction) { Factory[:auction, :default_scheduled_standard] }
 
   describe "#call" do
     subject(:contract) { described_class.new.call(attributes) }

--- a/spec/auction_fun_core/contracts/bid_context/create_bid_closed_contract_spec.rb
+++ b/spec/auction_fun_core/contracts/bid_context/create_bid_closed_contract_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe AuctionFunCore::Contracts::BidContext::CreateBidClosedContract, t
       end
 
       context 'when auction kind is different of "closed"' do
-        let(:auction) { Factory[:auction, :default_penny] }
+        let(:auction) { Factory[:auction, :default_scheduled_penny] }
         let(:attributes) { {auction_id: auction.id} }
 
         it "expect failure with error messages" do

--- a/spec/auction_fun_core/contracts/bid_context/create_bid_penny_contract_spec.rb
+++ b/spec/auction_fun_core/contracts/bid_context/create_bid_penny_contract_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe AuctionFunCore::Contracts::BidContext::CreateBidPennyContract, ty
       end
 
       context 'when auction kind is different of "penny"' do
-        let(:auction) { Factory[:auction, :default_standard] }
+        let(:auction) { Factory[:auction, :default_scheduled_standard] }
         let(:attributes) { {auction_id: auction.id} }
 
         it "expect failure with error messages" do

--- a/spec/auction_fun_core/contracts/bid_context/create_bid_standard_contract_spec.rb
+++ b/spec/auction_fun_core/contracts/bid_context/create_bid_standard_contract_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe AuctionFunCore::Contracts::BidContext::CreateBidStandardContract,
       end
 
       context 'when auction kind is different of "standard"' do
-        let(:auction) { Factory[:auction, :default_penny] }
+        let(:auction) { Factory[:auction, :default_scheduled_penny] }
         let(:attributes) { {auction_id: auction.id} }
 
         it "expect failure with error messages" do

--- a/spec/auction_fun_core/entities/auction_spec.rb
+++ b/spec/auction_fun_core/entities/auction_spec.rb
@@ -4,7 +4,7 @@ require "spec_helper"
 
 RSpec.describe AuctionFunCore::Entities::Auction, type: :entity do
   describe "#initial_bid" do
-    subject(:auction) { Factory.structs[:auction] }
+    subject(:auction) { Factory.structs[:auction, :default_scheduled_standard] }
 
     it "expect return initial bid as money object" do
       expect(auction.initial_bid).to be_a_instance_of(Money)
@@ -12,7 +12,7 @@ RSpec.describe AuctionFunCore::Entities::Auction, type: :entity do
   end
 
   describe "#minimal_bid" do
-    subject(:auction) { Factory.structs[:auction] }
+    subject(:auction) { Factory.structs[:auction, :default_scheduled_standard] }
 
     it "expect return minimal bid as money object" do
       expect(auction.minimal_bid).to be_a_instance_of(Money)
@@ -21,7 +21,7 @@ RSpec.describe AuctionFunCore::Entities::Auction, type: :entity do
 
   describe "#winner?" do
     context "when there is an associated FK" do
-      subject(:auction) { Factory.structs[:auction, :with_winner, winner_id: 1] }
+      subject(:auction) { Factory.structs[:auction, :default_finished_standard, :with_winner, winner_id: 1] }
 
       it "expects to return true when it has a winning user associated." do
         expect(auction.winner?).to be_truthy
@@ -29,7 +29,7 @@ RSpec.describe AuctionFunCore::Entities::Auction, type: :entity do
     end
 
     context "when there is no associated FK" do
-      subject(:auction) { Factory.structs[:auction] }
+      subject(:auction) { Factory.structs[:auction, :default_scheduled_standard] }
 
       it "expect return a user object" do
         expect(auction.winner?).to be_falsey

--- a/spec/auction_fun_core/operations/auction_context/create_operation_spec.rb
+++ b/spec/auction_fun_core/operations/auction_context/create_operation_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe AuctionFunCore::Operations::AuctionContext::CreateOperation, type
       context "when operation happens with success" do
         let(:staff) { Factory[:staff] }
         let(:attributes) do
-          Factory.structs[:auction, :default_standard, staff: staff]
+          Factory.structs[:auction, :default_scheduled_standard, staff: staff]
             .to_h.except(:id, :created_at, :updated_at, :staff)
         end
 
@@ -70,7 +70,7 @@ RSpec.describe AuctionFunCore::Operations::AuctionContext::CreateOperation, type
     context "when contract are valid" do
       let(:staff) { Factory[:staff] }
       let(:attributes) do
-        Factory.structs[:auction, :default_standard, staff: staff]
+        Factory.structs[:auction, :default_scheduled_standard, staff: staff]
           .to_h.except(:id, :created_at, :updated_at, :staff)
       end
 

--- a/spec/auction_fun_core/operations/auction_context/processor/pause_operation_spec.rb
+++ b/spec/auction_fun_core/operations/auction_context/processor/pause_operation_spec.rb
@@ -65,7 +65,10 @@ RSpec.describe AuctionFunCore::Operations::AuctionContext::Processor::PauseOpera
       let(:attributes) { {auction_id: auction.id} }
 
       it "expect update status auction record on database" do
-        expect { operation }.to change { auction_repository.by_id(auction.id).status }.from("running").to("paused")
+        expect { operation }
+          .to change { auction_repository.by_id(auction.id).status }
+          .from("running")
+          .to("paused")
       end
 
       it "expect publish the auction pause event" do

--- a/spec/auction_fun_core/operations/auction_context/processor/start_operation_spec.rb
+++ b/spec/auction_fun_core/operations/auction_context/processor/start_operation_spec.rb
@@ -4,7 +4,7 @@ require "spec_helper"
 
 RSpec.describe AuctionFunCore::Operations::AuctionContext::Processor::StartOperation, type: :operation do
   let(:auction_repository) { AuctionFunCore::Repos::AuctionContext::AuctionRepository.new }
-  let(:auction) { Factory[:auction, :default_standard, started_at: Time.current] }
+  let(:auction) { Factory[:auction, :default_scheduled_standard, started_at: Time.current] }
   let(:auction_id) { auction.id }
   let(:kind) { auction.kind }
   let(:stopwatch) { 0 }
@@ -97,7 +97,7 @@ RSpec.describe AuctionFunCore::Operations::AuctionContext::Processor::StartOpera
       end
 
       context "when auction kind is equal to 'closed'" do
-        let(:auction) { Factory[:auction, :default_closed, started_at: Time.current] }
+        let(:auction) { Factory[:auction, :default_scheduled_closed, started_at: Time.current] }
 
         it "expect create a new job to finish the closed auction" do
           allow(AuctionFunCore::Workers::Operations::AuctionContext::Processor::Finish::ClosedOperationJob).to receive(:perform_at)

--- a/spec/auction_fun_core/operations/auction_context/processor/start_operation_spec.rb
+++ b/spec/auction_fun_core/operations/auction_context/processor/start_operation_spec.rb
@@ -111,6 +111,7 @@ RSpec.describe AuctionFunCore::Operations::AuctionContext::Processor::StartOpera
       end
 
       context "when auction kind is equal to 'penny'" do
+        let(:auction) { Factory[:auction, :default_scheduled_closed, started_at: Time.current] }
         let(:stopwatch) { 45 }
         let(:old_finished_at) { auction.finished_at.strftime("%Y-%m-%d %H:%M:%S") }
         let(:new_finished_at) { stopwatch.seconds.from_now.strftime("%Y-%m-%d %H:%M:%S") }

--- a/spec/auction_fun_core/operations/bid_context/create_bid_closed_operation_spec.rb
+++ b/spec/auction_fun_core/operations/bid_context/create_bid_closed_operation_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe AuctionFunCore::Operations::BidContext::CreateBidClosedOperation,
 
     context "when block is given" do
       context "when operation happens with success" do
-        let(:auction) { Factory[:auction, :default_closed] }
+        let(:auction) { Factory[:auction, :default_scheduled_closed] }
         let(:user) { Factory[:user] }
         let(:attributes) do
           Factory.structs[:bid, user: user, auction: auction]
@@ -70,7 +70,7 @@ RSpec.describe AuctionFunCore::Operations::BidContext::CreateBidClosedOperation,
     end
 
     context "when contract are valid" do
-      let(:auction) { Factory[:auction, :default_closed] }
+      let(:auction) { Factory[:auction, :default_scheduled_closed] }
       let(:user) { Factory[:user] }
       let(:attributes) do
         Factory.structs[:bid, user: user, auction: auction]

--- a/spec/auction_fun_core/operations/bid_context/create_bid_penny_operation_spec.rb
+++ b/spec/auction_fun_core/operations/bid_context/create_bid_penny_operation_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe AuctionFunCore::Operations::BidContext::CreateBidPennyOperation, 
 
     context "when block is given" do
       context "when operation happens with success" do
-        let(:auction) { Factory[:auction, :default_penny] }
+        let(:auction) { Factory[:auction, :default_scheduled_penny] }
         let(:user) { Factory[:user] }
         let(:attributes) do
           Factory.structs[:bid, user: user, auction: auction]
@@ -70,7 +70,7 @@ RSpec.describe AuctionFunCore::Operations::BidContext::CreateBidPennyOperation, 
     end
 
     context "when contract are valid" do
-      let(:auction) { Factory[:auction, :default_penny] }
+      let(:auction) { Factory[:auction, :default_scheduled_penny] }
       let(:user) { Factory[:user] }
       let(:attributes) do
         Factory.structs[:bid, user: user, auction: auction]

--- a/spec/auction_fun_core/operations/bid_context/create_bid_standard_operation_spec.rb
+++ b/spec/auction_fun_core/operations/bid_context/create_bid_standard_operation_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe AuctionFunCore::Operations::BidContext::CreateBidStandardOperatio
 
     context "when block is given" do
       context "when operation happens with success" do
-        let(:auction) { Factory[:auction, :default_standard] }
+        let(:auction) { Factory[:auction, :default_scheduled_standard] }
         let(:user) { Factory[:user] }
         let(:attributes) do
           Factory.structs[:bid, user: user, auction: auction]
@@ -70,7 +70,7 @@ RSpec.describe AuctionFunCore::Operations::BidContext::CreateBidStandardOperatio
     end
 
     context "when contract are valid" do
-      let(:auction) { Factory[:auction, :default_standard] }
+      let(:auction) { Factory[:auction, :default_scheduled_standard] }
       let(:user) { Factory[:user] }
       let(:attributes) do
         Factory.structs[:bid, user: user, auction: auction]

--- a/spec/auction_fun_core/relations/auctions_spec.rb
+++ b/spec/auction_fun_core/relations/auctions_spec.rb
@@ -1,0 +1,471 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe AuctionFunCore::Relations::Auctions, type: :relations do
+  subject(:relation) { AuctionFunCore::Application[:container].relations[:auctions] }
+
+  describe "#all(page = 1, per_page = 10, options = { bidders_count: 3 })" do
+    subject(:object) { relation.all }
+
+    context "when page argument is a invalid input" do
+      it "expect raise exception" do
+        expect { relation.all(nil, 10) }.to raise_error(RuntimeError, "Invalid argument")
+      end
+    end
+
+    context "when per_page argument is a invalid input" do
+      it "expect raise exception" do
+        expect { relation.all(1, nil) }.to raise_error(RuntimeError, "Invalid argument")
+      end
+    end
+
+    it "expect include pagination on query" do
+      expect(relation.all.dataset.sql).to include("LIMIT 10 OFFSET 0")
+    end
+
+    context "when there are no auctions available" do
+      subject(:results) { relation.all.to_a }
+
+      it "expect return empty data" do
+        expect(results).to eq(Dry::Core::Constants::EMPTY_ARRAY)
+      end
+    end
+
+    context "when there is an auction available without bids" do
+      subject(:result) { relation.all.first }
+
+      let!(:auction) { Factory[:auction, :default_scheduled_standard] }
+
+      it "expect return auction attributes with empty bids" do
+        expect(result).to be_a_instance_of(ROM::OpenStruct)
+        expect(result.bids).to eq({
+          "current" => auction.initial_bid_cents,
+          "minimal" => auction.minimal_bid_cents,
+          "bidders" => Dry::Core::Constants::EMPTY_ARRAY
+        })
+        expect(result.description).to eq(auction.description)
+        expect(result.finished_at).to eq(auction.finished_at)
+        expect(result.id).to eq(auction.id)
+        expect(result.initial_bid_cents).to eq(auction.initial_bid_cents)
+        expect(result.kind).to eq(auction.kind)
+        expect(result.started_at).to eq(auction.started_at)
+        expect(result.status).to eq(auction.status)
+        expect(result.stopwatch).to eq(auction.stopwatch)
+        expect(result.title).to eq(auction.title)
+        expect(result.total_bids).to be_zero
+      end
+    end
+
+    context "when there is an auction available with bids" do
+      subject(:result) { relation.all.first }
+
+      let!(:auction) { Factory[:auction, :default_scheduled_standard] }
+      let!(:winner) { Factory[:user] }
+      let!(:bid) do
+        Factory[:bid, auction: auction, user: winner, value_cents: auction.minimal_bid_cents, value_currency: auction.minimal_bid_currency]
+      end
+
+      it "expect return auction attributes with bids info" do
+        expect(result).to be_a_instance_of(ROM::OpenStruct)
+        expect(result.bids.to_h).to include({
+          "current" => bid.value_cents,
+          "minimal" => auction.minimal_bid_cents,
+          "bidders" => [{
+            "id" => bid.id,
+            "user_id" => winner.id,
+            "name" => winner.name,
+            "value" => bid.value_cents,
+            "date" => bid.created_at.strftime("%Y-%m-%dT%H:%M:%S.%6N")
+          }]
+        })
+        expect(result.description).to eq(auction.description)
+        expect(result.finished_at).to eq(auction.finished_at)
+        expect(result.id).to eq(auction.id)
+        expect(result.initial_bid_cents).to eq(auction.initial_bid_cents)
+        expect(result.kind).to eq(auction.kind)
+        expect(result.started_at).to eq(auction.started_at)
+        expect(result.status).to eq(auction.status)
+        expect(result.stopwatch).to eq(auction.stopwatch)
+        expect(result.title).to eq(auction.title)
+        expect(result.total_bids).to eq(1)
+      end
+    end
+  end
+
+  describe "#info(auction_id, options = { bidders_count: 3 })" do
+    subject(:object) { relation.info(auction_id) }
+
+    let(:auction) { Factory[:auction, :default_scheduled_standard] }
+    let(:auction_id) { auction.id }
+
+    context "when there are no auctions available" do
+      subject(:result) { relation.info(2_234_231).one }
+
+      it "expect return empty data" do
+        expect(result).to be_blank
+      end
+    end
+
+    context "when there is an auction available without bids" do
+      subject(:result) { relation.info(auction_id).one }
+
+      it "expect return auction attributes with empty bids" do
+        expect(result).to be_a_instance_of(ROM::OpenStruct)
+        expect(result.bids).to eq({
+          "current" => auction.initial_bid_cents,
+          "minimal" => auction.minimal_bid_cents,
+          "bidders" => Dry::Core::Constants::EMPTY_ARRAY
+        })
+        expect(result.description).to eq(auction.description)
+        expect(result.finished_at).to eq(auction.finished_at)
+        expect(result.id).to eq(auction.id)
+        expect(result.initial_bid_cents).to eq(auction.initial_bid_cents)
+        expect(result.kind).to eq(auction.kind)
+        expect(result.started_at).to eq(auction.started_at)
+        expect(result.status).to eq(auction.status)
+        expect(result.stopwatch).to eq(auction.stopwatch)
+        expect(result.title).to eq(auction.title)
+        expect(result.total_bids).to be_zero
+      end
+    end
+
+    context "when there is an auction available with bids" do
+      subject(:result) { relation.all.first }
+
+      let!(:auction) { Factory[:auction, :default_scheduled_standard] }
+      let!(:winner) { Factory[:user] }
+      let!(:bid) do
+        Factory[:bid, auction: auction, user: winner, value_cents: auction.minimal_bid_cents, value_currency: auction.minimal_bid_currency]
+      end
+
+      it "expect return auction attributes with bids info" do
+        expect(result).to be_a_instance_of(ROM::OpenStruct)
+        expect(result.bids.to_h).to include({
+          "current" => bid.value_cents,
+          "minimal" => auction.minimal_bid_cents,
+          "bidders" => [{
+            "id" => bid.id,
+            "user_id" => winner.id,
+            "name" => winner.name,
+            "value" => bid.value_cents,
+            "date" => bid.created_at.strftime("%Y-%m-%dT%H:%M:%S.%6N")
+          }]
+        })
+        expect(result.description).to eq(auction.description)
+        expect(result.finished_at).to eq(auction.finished_at)
+        expect(result.id).to eq(auction.id)
+        expect(result.initial_bid_cents).to eq(auction.initial_bid_cents)
+        expect(result.kind).to eq(auction.kind)
+        expect(result.started_at).to eq(auction.started_at)
+        expect(result.status).to eq(auction.status)
+        expect(result.stopwatch).to eq(auction.stopwatch)
+        expect(result.title).to eq(auction.title)
+        expect(result.total_bids).to eq(1)
+      end
+    end
+  end
+
+  describe "#load_standard_auction_winners_and_participants(auction_id)" do
+    subject(:result) { relation.load_standard_auction_winners_and_participants(auction.id).one }
+
+    context "when there are no auctions available" do
+      subject(:result) { relation.load_standard_auction_winners_and_participants(2_234_231).one }
+
+      it "expect return empty data" do
+        expect(result).to be_blank
+      end
+    end
+
+    context "when there is an auction available without bids" do
+      let!(:auction) { Factory[:auction, :default_finished_standard] }
+
+      it "expect return auction data without winner and participants info" do
+        expect(result.id).to eq(auction.id)
+        expect(result.kind).to eq(auction.kind)
+        expect(result.participant_ids).to eq(Dry::Core::Constants::EMPTY_ARRAY)
+        expect(result.status).to eq(auction.status)
+        expect(result.total_bids).to be_zero
+        expect(result.winner_id).to be_nil
+      end
+    end
+
+    context "when the auction has only one bid (winner)" do
+      let!(:auction) { Factory[:auction, :default_finished_standard] }
+      let!(:winner) { Factory[:user] }
+      let!(:bid) do
+        Factory[:bid, auction: auction, user: winner, value_cents: auction.minimal_bid_cents, value_currency: auction.minimal_bid_currency]
+      end
+
+      it "expect return auction data with winner and no participants info" do
+        expect(result.id).to eq(auction.id)
+        expect(result.kind).to eq(auction.kind)
+        expect(result.participant_ids).to eq(Dry::Core::Constants::EMPTY_ARRAY)
+        expect(result.status).to eq(auction.status)
+        expect(result.total_bids).to eq(1)
+        expect(result.winner_id).to eq(winner.id)
+      end
+    end
+
+    context "when the auction has more than one bid (winner and participants)" do
+      let!(:auction) { Factory[:auction, :default_finished_standard] }
+      let!(:winner) { Factory[:user] }
+      let!(:participant) { Factory[:user] }
+      let!(:bid) do
+        Factory[:bid, auction: auction, user: participant, value_cents: auction.minimal_bid_cents, value_currency: auction.minimal_bid_currency]
+        Factory[:bid, auction: auction, user: winner, value_cents: auction.minimal_bid_cents, value_currency: auction.minimal_bid_currency]
+      end
+
+      it "expect return auction data with winner with participants" do
+        expect(result.id).to eq(auction.id)
+        expect(result.kind).to eq(auction.kind)
+        expect(result.participant_ids).to include(participant.id)
+        expect(result.status).to eq(auction.status)
+        expect(result.total_bids).to eq(2)
+        expect(result.winner_id).to eq(winner.id)
+      end
+    end
+  end
+
+  describe "#load_penny_auction_winners_and_participants(auction_id)" do
+    subject(:result) { relation.load_penny_auction_winners_and_participants(auction.id).one }
+
+    context "when there are no auctions available" do
+      subject(:result) { relation.load_penny_auction_winners_and_participants(2_234_231).one }
+
+      it "expect return empty data" do
+        expect(result).to be_blank
+      end
+    end
+
+    context "when there is an auction available without bids" do
+      let!(:auction) { Factory[:auction, :default_finished_standard] }
+
+      it "expect return auction data without winner and participants info" do
+        expect(result.id).to eq(auction.id)
+        expect(result.kind).to eq(auction.kind)
+        expect(result.participant_ids).to eq(Dry::Core::Constants::EMPTY_ARRAY)
+        expect(result.status).to eq(auction.status)
+        expect(result.total_bids).to be_zero
+        expect(result.winner_id).to be_nil
+      end
+    end
+
+    context "when the auction has only one bid (winner)" do
+      let!(:auction) { Factory[:auction, :default_finished_standard] }
+      let!(:winner) { Factory[:user] }
+      let!(:bid) do
+        Factory[:bid, auction: auction, user: winner, value_cents: auction.minimal_bid_cents, value_currency: auction.minimal_bid_currency]
+      end
+
+      it "expect return auction data with winner and no participants info" do
+        expect(result.id).to eq(auction.id)
+        expect(result.kind).to eq(auction.kind)
+        expect(result.participant_ids).to eq(Dry::Core::Constants::EMPTY_ARRAY)
+        expect(result.status).to eq(auction.status)
+        expect(result.total_bids).to eq(1)
+        expect(result.winner_id).to eq(winner.id)
+      end
+    end
+
+    context "when the auction has more than one bid (winner and participants)" do
+      let!(:auction) { Factory[:auction, :default_finished_standard] }
+      let!(:winner) { Factory[:user] }
+      let!(:participant) { Factory[:user] }
+      let!(:bid) do
+        Factory[:bid, auction: auction, user: participant, value_cents: auction.minimal_bid_cents, value_currency: auction.minimal_bid_currency]
+        Factory[:bid, auction: auction, user: winner, value_cents: auction.minimal_bid_cents, value_currency: auction.minimal_bid_currency]
+      end
+
+      it "expect return auction data with winner with participants" do
+        expect(result.id).to eq(auction.id)
+        expect(result.kind).to eq(auction.kind)
+        expect(result.participant_ids).to include(participant.id)
+        expect(result.status).to eq(auction.status)
+        expect(result.total_bids).to eq(2)
+        expect(result.winner_id).to eq(winner.id)
+      end
+    end
+  end
+
+  describe "#load_closed_auction_winners_and_participants(auction_id)" do
+    subject(:result) { relation.load_closed_auction_winners_and_participants(auction.id).one }
+
+    context "when there are no auctions available" do
+      subject(:result) { relation.load_closed_auction_winners_and_participants(2_234_231).one }
+
+      it "expect return empty data" do
+        expect(result).to be_blank
+      end
+    end
+
+    context "when there is an auction available without bids" do
+      let!(:auction) { Factory[:auction, :default_finished_standard] }
+
+      it "expect return auction data without winner and participants info" do
+        expect(result.id).to eq(auction.id)
+        expect(result.kind).to eq(auction.kind)
+        expect(result.participant_ids).to eq(Dry::Core::Constants::EMPTY_ARRAY)
+        expect(result.status).to eq(auction.status)
+        expect(result.total_bids).to be_zero
+        expect(result.winner_id).to be_nil
+      end
+    end
+
+    context "when the auction has only one bid (winner)" do
+      let!(:auction) { Factory[:auction, :default_finished_standard] }
+      let!(:winner) { Factory[:user] }
+      let!(:bid) do
+        Factory[:bid, auction: auction, user: winner, value_cents: auction.minimal_bid_cents, value_currency: auction.minimal_bid_currency]
+      end
+
+      it "expect return auction data with winner and no participants info" do
+        expect(result.id).to eq(auction.id)
+        expect(result.kind).to eq(auction.kind)
+        expect(result.participant_ids).to eq(Dry::Core::Constants::EMPTY_ARRAY)
+        expect(result.status).to eq(auction.status)
+        expect(result.total_bids).to eq(1)
+        expect(result.winner_id).to eq(winner.id)
+      end
+    end
+
+    context "when the auction has more than one bid (winner and participants)" do
+      let!(:auction) { Factory[:auction, :default_finished_standard] }
+      let!(:winner) { Factory[:user] }
+      let!(:participant) { Factory[:user] }
+      let!(:bid) do
+        Factory[:bid, auction: auction, user: participant, value_cents: auction.minimal_bid_cents, value_currency: auction.minimal_bid_currency]
+        Factory[:bid, auction: auction, user: winner, value_cents: auction.minimal_bid_cents, value_currency: auction.minimal_bid_currency]
+      end
+
+      it "expect return auction data with winner with participants" do
+        expect(result.id).to eq(auction.id)
+        expect(result.kind).to eq(auction.kind)
+        expect(result.participant_ids).to include(participant.id)
+        expect(result.status).to eq(auction.status)
+        expect(result.total_bids).to eq(2)
+        expect(result.winner_id).to eq(winner.id)
+      end
+    end
+  end
+
+  describe "#load_winner_statistics(auction_id, winner_id)" do
+    context "when auction_id argument is a invalid input" do
+      it "expect raise exception" do
+        expect { relation.load_winner_statistics(nil, 10) }.to raise_error(RuntimeError, "Invalid argument")
+      end
+    end
+
+    context "when winner_id argument is a invalid input" do
+      it "expect raise exception" do
+        expect { relation.load_winner_statistics(1, nil) }.to raise_error(RuntimeError, "Invalid argument")
+      end
+    end
+
+    context "when there are no auctions available" do
+      subject(:result) { relation.load_winner_statistics(2_234_231, winner.id).one }
+
+      let(:winner) { Factory[:user] }
+
+      it "expect return empty data" do
+        expect(result).to be_blank
+      end
+    end
+
+    context "when there is no bid" do
+      subject(:result) { relation.load_winner_statistics(auction.id, winner.id).one }
+
+      let(:auction) { Factory[:auction, :default_finished_standard] }
+      let(:winner) { Factory[:user] }
+
+      it "expect return auction attributes without winner and without participants" do
+        expect(result.id).to eq(auction.id)
+        expect(result.auction_total_bids).to be_zero
+        expect(result.winner_total_bids).to be_zero
+        expect(result.winner_bid).to be_nil
+      end
+    end
+
+    context "when there is at least one bid" do
+      subject(:result) { relation.load_winner_statistics(auction.id, winner.id).one }
+
+      let!(:auction) { Factory[:auction, :default_finished_standard] }
+      let!(:winner) { Factory[:user] }
+      let!(:winner_bid_value) { auction.minimal_bid_cents * 2 }
+      let!(:participant) { Factory[:user] }
+      let!(:participant_bid) do
+        Factory[:bid, auction: auction, user: participant, value_cents: auction.minimal_bid_cents, value_currency: auction.minimal_bid_currency]
+      end
+      let!(:winner_bid) do
+        Factory[:bid, auction: auction, user: winner, value_cents: winner_bid_value, value_currency: auction.minimal_bid_currency]
+      end
+
+      it "expect return auction attributes without winner and without participants" do
+        expect(result.id).to eq(auction.id)
+        expect(result.auction_total_bids).to eq(2)
+        expect(result.winner_total_bids).to eq(1)
+        expect(result.winner_bid).to eq(winner_bid_value)
+      end
+    end
+  end
+
+  describe "#load_participant_statistics(auction_id, participant_id)" do
+    context "when auction_id argument is a invalid input" do
+      it "expect raise exception" do
+        expect { relation.load_participant_statistics(nil, 10) }.to raise_error(RuntimeError, "Invalid argument")
+      end
+    end
+
+    context "when participant_id argument is a invalid input" do
+      it "expect raise exception" do
+        expect { relation.load_participant_statistics(1, nil) }.to raise_error(RuntimeError, "Invalid argument")
+      end
+    end
+
+    context "when there are no auctions available" do
+      subject(:result) { relation.load_participant_statistics(2_234_231, winner.id).one }
+
+      let(:winner) { Factory[:user] }
+
+      it "expect return empty data" do
+        expect(result).to be_blank
+      end
+    end
+
+    context "when there is no bid" do
+      subject(:result) { relation.load_participant_statistics(auction.id, participant.id).one }
+
+      let(:auction) { Factory[:auction, :default_finished_standard] }
+      let(:participant) { Factory[:user] }
+
+      it "expect return auction attributes without winner and without participants" do
+        expect(result.id).to eq(auction.id)
+        expect(result.auction_total_bids).to be_zero
+        expect(result.winner_total_bids).to be_zero
+        expect(result.winner_bid).to be_nil
+      end
+    end
+
+    context "when there is at least one bid" do
+      subject(:result) { relation.load_participant_statistics(auction.id, participant.id).one }
+
+      let!(:auction) { Factory[:auction, :default_finished_standard] }
+      let!(:winner) { Factory[:user] }
+      let!(:winner_bid_value) { auction.minimal_bid_cents * 2 }
+      let!(:participant) { Factory[:user] }
+      let!(:participant_bid) do
+        Factory[:bid, auction: auction, user: participant, value_cents: auction.minimal_bid_cents, value_currency: auction.minimal_bid_currency]
+      end
+      let!(:winner_bid) do
+        Factory[:bid, auction: auction, user: winner, value_cents: winner_bid_value, value_currency: auction.minimal_bid_currency]
+      end
+
+      it "expect return auction attributes without winner and without participants" do
+        expect(result.id).to eq(auction.id)
+        expect(result.auction_total_bids).to eq(2)
+        expect(result.winner_total_bids).to eq(1)
+        expect(result.winner_bid).to eq(winner_bid_value)
+      end
+    end
+  end
+end

--- a/spec/auction_fun_core/repos/auction_context/auction_repository_spec.rb
+++ b/spec/auction_fun_core/repos/auction_context/auction_repository_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe AuctionFunCore::Repos::AuctionContext::AuctionRepository, type: :
   subject(:repo) { described_class.new }
 
   describe "#all" do
-    let!(:auction) { Factory[:auction, :default_standard] }
+    let!(:auction) { Factory[:auction, :default_scheduled_standard] }
 
     it "expect return all auctions" do
       expect(repo.all.size).to eq(1)
@@ -22,7 +22,7 @@ RSpec.describe AuctionFunCore::Repos::AuctionContext::AuctionRepository, type: :
     end
 
     context "when has auctions on repository" do
-      let!(:auction) { Factory[:auction, :default_standard] }
+      let!(:auction) { Factory[:auction, :default_scheduled_standard] }
 
       it "expect return total" do
         expect(repo.count).to eq(1)
@@ -32,7 +32,7 @@ RSpec.describe AuctionFunCore::Repos::AuctionContext::AuctionRepository, type: :
 
   describe "#by_id(id)" do
     context "when id is founded on repository" do
-      let!(:auction) { Factory[:auction, :default_standard] }
+      let!(:auction) { Factory[:auction, :default_scheduled_standard] }
 
       it "expect return rom object" do
         expect(repo.by_id(auction.id)).to be_a(AuctionFunCore::Entities::Auction)
@@ -48,7 +48,7 @@ RSpec.describe AuctionFunCore::Repos::AuctionContext::AuctionRepository, type: :
 
   describe "#by_id!(id)" do
     context "when id is founded on repository" do
-      let!(:auction) { Factory[:auction, :default_standard] }
+      let!(:auction) { Factory[:auction, :default_scheduled_standard] }
 
       it "expect return rom object" do
         expect(repo.by_id(auction.id)).to be_a(AuctionFunCore::Entities::Auction)

--- a/spec/auction_fun_core/repos/bid_context/bid_repository_spec.rb
+++ b/spec/auction_fun_core/repos/bid_context/bid_repository_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe AuctionFunCore::Repos::BidContext::BidRepository, type: :repo do
   subject(:repo) { described_class.new }
 
   describe "#create" do
-    let(:auction) { Factory[:auction, :default_standard] }
+    let(:auction) { Factory[:auction, :default_scheduled_standard] }
     let(:user) { Factory[:user] }
 
     let(:bid) do

--- a/spec/auction_fun_core/repos/staff_context/staff_repository_spec.rb
+++ b/spec/auction_fun_core/repos/staff_context/staff_repository_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe AuctionFunCore::Repos::StaffContext::StaffRepository, type: :repo
         name: attributes.name,
         email: attributes.email,
         phone: attributes.phone,
+        kind: "common",
         password_digest: BCrypt::Password.create("password")
       )
     end

--- a/spec/auction_fun_core/services/mail/auction_context/post_auction/participant_mailer_spec.rb
+++ b/spec/auction_fun_core/services/mail/auction_context/post_auction/participant_mailer_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe AuctionFunCore::Services::Mail::AuctionContext::PostAuction::Part
 
     context "when participant has invalid data" do
       let(:participant) { Factory.structs[:user, id: 1, email: nil] }
-      let(:auction) { Factory.structs[:auction, id: 1] }
+      let(:auction) { Factory.structs[:auction, :default_finished_standard, id: 1] }
       let(:statistics) { OpenStruct.new(auction_date: Date.current) }
 
       it "expect raise error" do

--- a/spec/auction_fun_core/services/mail/auction_context/post_auction/winner_mailer_spec.rb
+++ b/spec/auction_fun_core/services/mail/auction_context/post_auction/winner_mailer_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe AuctionFunCore::Services::Mail::AuctionContext::PostAuction::Winn
 
     context "when winner has invalid data" do
       let(:winner) { Factory.structs[:user, email: nil] }
-      let(:auction) { Factory.structs[:auction, id: 1] }
+      let(:auction) { Factory.structs[:auction, :default_finished_standard, id: 1] }
       let(:statistics) { OpenStruct.new(auction_date: Date.current) }
 
       it "expect raise error" do

--- a/spec/auction_fun_core/workers/operations/auction_context/post_auction/participation_operation_job_spec.rb
+++ b/spec/auction_fun_core/workers/operations/auction_context/post_auction/participation_operation_job_spec.rb
@@ -5,7 +5,7 @@ require "spec_helper"
 RSpec.describe AuctionFunCore::Workers::Operations::AuctionContext::PostAuction::ParticipantOperationJob, type: :worker do
   let(:auction_repository) { AuctionFunCore::Repos::AuctionContext::AuctionRepository.new }
   let(:participant) { Factory[:user] }
-  let(:auction) { Factory[:auction, :default_standard, :with_winner] }
+  let(:auction) { Factory[:auction, :default_finished_standard, :with_winner] }
 
   describe "#perform" do
     subject(:worker) { described_class.new }

--- a/spec/auction_fun_core/workers/operations/auction_context/post_auction/winner_operation_job_spec.rb
+++ b/spec/auction_fun_core/workers/operations/auction_context/post_auction/winner_operation_job_spec.rb
@@ -4,7 +4,7 @@ require "spec_helper"
 
 RSpec.describe AuctionFunCore::Workers::Operations::AuctionContext::PostAuction::WinnerOperationJob, type: :worker do
   let(:auction_repository) { AuctionFunCore::Repos::AuctionContext::AuctionRepository.new }
-  let(:auction) { Factory[:auction, :default_standard, :with_winner] }
+  let(:auction) { Factory[:auction, :default_finished_standard, :with_winner] }
 
   describe "#perform" do
     subject(:worker) { described_class.new }

--- a/spec/auction_fun_core/workers/operations/auction_context/processor/start_operation_job_spec.rb
+++ b/spec/auction_fun_core/workers/operations/auction_context/processor/start_operation_job_spec.rb
@@ -4,7 +4,7 @@ require "spec_helper"
 
 RSpec.describe AuctionFunCore::Workers::Operations::AuctionContext::Processor::StartOperationJob, type: :worker do
   let(:auction_repository) { AuctionFunCore::Repos::AuctionContext::AuctionRepository.new }
-  let(:auction) { Factory[:auction, :default_standard] }
+  let(:auction) { Factory[:auction, :default_scheduled_standard] }
 
   describe "#perform" do
     subject(:worker) { described_class.new }

--- a/spec/auction_fun_core_spec.rb
+++ b/spec/auction_fun_core_spec.rb
@@ -2,6 +2,6 @@
 
 RSpec.describe AuctionFunCore do
   it "has a version number" do
-    expect(AuctionFunCore::VERSION).to eq("0.8.6")
+    expect(AuctionFunCore::VERSION).to eq("0.8.7")
   end
 end

--- a/spec/support/factories/auctions.rb
+++ b/spec/support/factories/auctions.rb
@@ -65,8 +65,9 @@ Factory.define(:auction, struct_namespace: AuctionFunCore::Entities) do |f|
     t.finished_at { 2.days.from_now }
   end
 
-  f.trait :default_standard do |t|
+  f.trait :default_scheduled_standard do |t|
     t.kind { "standard" }
+    t.status { "scheduled" }
 
     t.started_at { 1.hour.from_now }
     t.finished_at { 1.week.from_now }
@@ -104,8 +105,9 @@ Factory.define(:auction, struct_namespace: AuctionFunCore::Entities) do |f|
     t.minimal_bid_cents { 100 }
   end
 
-  f.trait :default_penny do |t|
+  f.trait :default_scheduled_penny do |t|
     t.kind { "penny" }
+    t.status { "scheduled" }
 
     t.stopwatch { AuctionFunCore::Business::Configuration::AUCTION_STOPWATCH_MIN_VALUE }
     t.started_at { 1.hour.from_now }
@@ -121,8 +123,9 @@ Factory.define(:auction, struct_namespace: AuctionFunCore::Entities) do |f|
     t.initial_bid_cents { 100 }
   end
 
-  f.trait :default_closed do |t|
+  f.trait :default_scheduled_closed do |t|
     t.kind { "closed" }
+    t.status { "scheduled" }
 
     t.initial_bid_cents { 100 }
     t.started_at { 1.hour.from_now }

--- a/spec/support/factories/bids.rb
+++ b/spec/support/factories/bids.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 Factory.define(:bid, struct_namespace: AuctionFunCore::Entities) do |f|
-  f.association(:auction, :default_standard)
+  f.association(:auction, :default_scheduled_standard)
   f.association(:user)
 end


### PR DESCRIPTION
Issue number: resolves #40 

## Summary :red_circle:

In the auction completion task, a different behavior was noticed than the standard of most ORM's that use OO. When an object is updated in the database, the object itself already carries the update made (activerecord is like this, for example). However, we are using rom-rb which, behind the scenes, makes use of object immutability (which is quite performant in terms of GC). Although we gain in performance, in most cases we need the behavior in which the object returns updated, thus being able to return it to the flow of operations.

ROM-RB, in its update operation, updates the db, however, returns a new object. This new object, however, in the case of standard attributes, returns the default values and not the updated values. With this in mind, we will make the following changes outlined in the checklist. The version `0.8.7` CHANGELOG contains all the details.

## Proposed / Possible solution :red_circle:

- Specific refactorings are better described in the Checklist section.

## Checklist

- [x] Removing default values from relations.
- [x] Rebuild factories to not contain default values (but rather be set manually or built from traits).
- [x] Add automated tests for auction relations