### PR TITLE
[AF-45] Allow test files when publishing the gem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## [Unreleased]
 
+## [0.8.10] - 2024-04-30
+
+### Changed
+
+- Allow spec files when publishing the gem;
+
 ## [0.8.9] - 2024-04-29
 
 ### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    auction_fun_core (0.8.9)
+    auction_fun_core (0.8.10)
       activesupport (= 7.1.3.2)
       bcrypt (= 3.1.20)
       dotenv (= 3.1.0)

--- a/auction_fun_core.gemspec
+++ b/auction_fun_core.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.files = Dir.chdir(__dir__) do
     `git ls-files -z`.split("\x0").reject do |f|
       (File.expand_path(f) == __FILE__) ||
-        f.start_with?(*%w[bin/ test/ spec/ features/ .git .github appveyor Gemfile])
+        f.start_with?(*%w[bin/ test/ features/ .git .github appveyor Gemfile])
     end
   end
   spec.bindir = "exe"

--- a/lib/auction_fun_core/version.rb
+++ b/lib/auction_fun_core/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module AuctionFunCore
-  VERSION = "0.8.9"
+  VERSION = "0.8.10"
 
   # Required class module is a gem dependency
   class Version; end

--- a/spec/auction_fun_core_spec.rb
+++ b/spec/auction_fun_core_spec.rb
@@ -2,6 +2,6 @@
 
 RSpec.describe AuctionFunCore do
   it "has a version number" do
-    expect(AuctionFunCore::VERSION).to eq("0.8.9")
+    expect(AuctionFunCore::VERSION).to eq("0.8.10")
   end
 end


### PR DESCRIPTION
Issue number: resolves #45 

## Summary :red_circle:

Although unnecessary to run in a production environment, in the integration with the API, factories are used to test the data on the endpoints. Therefore, from version `0.8.10` onwards, the test files will be available when publishing the gem.

## Proposed / Possible solution :red_circle:

Configure the auction_fun_core.gemspec file so that in the files option (spec.files) it no longer ignores the tests directory (specs).

## How to test :policeman:

Update the gem core version in the API and check it in the test suite in CI.

## Risks / Impacts :red_circle:

- None anticipated

## Requirements for deployment :red_circle:

- None anticipated